### PR TITLE
Handling JsonNull to JsonPrimitive

### DIFF
--- a/core/src/main/kotlin/br/com/guiabolso/events/model/Event.kt
+++ b/core/src/main/kotlin/br/com/guiabolso/events/model/Event.kt
@@ -1,10 +1,10 @@
 package br.com.guiabolso.events.model
 
 import br.com.guiabolso.events.json.MapperHolder
+import br.com.guiabolso.events.validation.withCheckedJsonNull
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
 import java.lang.IllegalStateException
-
 
 sealed class Event {
     abstract val name: String
@@ -29,11 +29,14 @@ sealed class Event {
     inline fun <reified T> authAs(): T = MapperHolder.mapper.fromJson(this.auth, T::class.java)
 
     val userId: Long?
-        get() = this.identity.getAsJsonPrimitive("userId")?.asLong
+        get() = this.identity.withCheckedJsonNull("userId") {
+            it.getAsJsonPrimitive("userId")?.asLong
+        }
 
     val origin: String?
-        get() = this.metadata.getAsJsonPrimitive("origin")?.asString
-
+        get() = this.metadata.withCheckedJsonNull("origin") {
+            it.getAsJsonPrimitive("origin")?.asString
+        }
 }
 
 data class ResponseEvent(

--- a/core/src/main/kotlin/br/com/guiabolso/events/validation/TypeValidationHelper.kt
+++ b/core/src/main/kotlin/br/com/guiabolso/events/validation/TypeValidationHelper.kt
@@ -4,4 +4,8 @@ import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 
 fun <T> JsonObject.withCheckedJsonNull(checkedParam: String, block: (jsonObject: JsonObject) -> T?): T? =
-        if(this.get(checkedParam) is JsonNull) null else block(this)
+        if (this.get(checkedParam) is JsonNull) {
+            null
+        } else {
+            block(this)
+        }

--- a/core/src/main/kotlin/br/com/guiabolso/events/validation/TypeValidationHelper.kt
+++ b/core/src/main/kotlin/br/com/guiabolso/events/validation/TypeValidationHelper.kt
@@ -3,5 +3,5 @@ package br.com.guiabolso.events.validation
 import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 
-fun <T> JsonObject.withCheckedJsonNull(checkedParam: String, block: (jsonObject: JsonObject) -> T): T? =
+fun <T> JsonObject.withCheckedJsonNull(checkedParam: String, block: (jsonObject: JsonObject) -> T?): T? =
         if(this.get(checkedParam) is JsonNull) null else block(this)

--- a/core/src/main/kotlin/br/com/guiabolso/events/validation/TypeValidationHelper.kt
+++ b/core/src/main/kotlin/br/com/guiabolso/events/validation/TypeValidationHelper.kt
@@ -1,0 +1,7 @@
+package br.com.guiabolso.events.validation
+
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+
+fun <T> JsonObject.withCheckedJsonNull(checkedParam: String, block: (jsonObject: JsonObject) -> T): T? =
+        if(this.get(checkedParam) is JsonNull) null else block(this)

--- a/core/src/test/kotlin/br/com/guiabolso/events/model/EventErrorTypeTest.kt
+++ b/core/src/test/kotlin/br/com/guiabolso/events/model/EventErrorTypeTest.kt
@@ -1,8 +1,12 @@
 package br.com.guiabolso.events.model
 
+import br.com.guiabolso.events.EventBuilderForTest
+import br.com.guiabolso.events.json.MapperHolder
 import br.com.guiabolso.events.model.EventErrorType.*
 import br.com.guiabolso.events.model.EventErrorType.Companion.getErrorType
+import com.google.gson.JsonObject
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
 class EventErrorTypeTest {
@@ -25,4 +29,55 @@ class EventErrorTypeTest {
         assertEquals("somethingElse", getErrorType("somethingElse").typeName)
     }
 
+    @Test
+    fun testJsonNullUserIdEvent() {
+        val identity = MapperHolder.mapper.fromJson("""
+            {
+                "userId": null
+            }
+        """.trimIndent(), JsonObject::class.java)
+
+        val event = EventBuilderForTest.buildRequestEvent().copy(identity = identity)
+
+        assertNull(event.userId)
+    }
+
+    @Test
+    fun testJsonNullOriginEvent() {
+        val metadata = MapperHolder.mapper.fromJson("""
+            {
+                "origin": null
+            }
+        """.trimIndent(), JsonObject::class.java)
+
+        val event = EventBuilderForTest.buildRequestEvent().copy(metadata = metadata)
+
+        assertNull(event.origin)
+    }
+
+    @Test
+    fun testNotNullUserIdEvent() {
+        val identity = MapperHolder.mapper.fromJson("""
+            {
+                "userId": 123987
+            }
+        """.trimIndent(), JsonObject::class.java)
+
+        val event = EventBuilderForTest.buildRequestEvent().copy(identity = identity)
+
+        assertEquals(123987L, event.userId)
+    }
+
+    @Test
+    fun testNotNullOriginEvent() {
+        val metadata = MapperHolder.mapper.fromJson("""
+            {
+                "origin": "east"
+            }
+        """.trimIndent(), JsonObject::class.java)
+
+        val event = EventBuilderForTest.buildRequestEvent().copy(metadata = metadata)
+
+        assertEquals("east", event.origin)
+    }
 }

--- a/core/src/test/kotlin/br/com/guiabolso/events/validation/TypeValidationHelper.kt
+++ b/core/src/test/kotlin/br/com/guiabolso/events/validation/TypeValidationHelper.kt
@@ -1,0 +1,42 @@
+package br.com.guiabolso.events.validation
+
+import br.com.guiabolso.events.json.MapperHolder
+import com.google.gson.JsonObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class TypeValidationHelper {
+
+    @Test
+    fun testWithCheckedJsonNullWithNullInput() {
+
+        val jsonObj = MapperHolder.mapper.fromJson("""
+        {
+            "userId": null
+        }
+        """.trimIndent(), JsonObject::class.java)
+
+        val userId = jsonObj.withCheckedJsonNull("userId") {
+            it.getAsJsonPrimitive("userId")
+        }
+
+        assertNull(userId)
+    }
+
+    @Test
+    fun testWithCheckedJsonNullWithValidInput() {
+
+        val identityJsonObj = MapperHolder.mapper.fromJson("""
+            {
+                "userId": 123987
+            }
+        """.trimIndent(), JsonObject::class.java)
+
+        val userId = identityJsonObj.withCheckedJsonNull("userId") {
+            it.getAsJsonPrimitive("userId").asLong
+        }
+
+        assertEquals(123987L, userId)
+    }
+}

--- a/core/src/test/kotlin/br/com/guiabolso/events/validation/TypeValidationHelperTest.kt
+++ b/core/src/test/kotlin/br/com/guiabolso/events/validation/TypeValidationHelperTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 
-class TypeValidationHelper {
+class TypeValidationHelperTest {
 
     @Test
     fun testWithCheckedJsonNullWithNullInput() {


### PR DESCRIPTION
### Problem
When retrieving `userId` and `origin` field from `Event` instance, the following error occurs: 
```java
Caused by: java.lang.ClassCastException: com.google.gson.JsonNull cannot be cast to com.google.gson.JsonPrimitive
```
This problem happens when the client inputs a null value. This value is converted to an instance of  `JsonNull` and this can't be cast to `JsonPrimitive`. 