### PR TITLE
Adicionando abstração para facilitar o uso da lib em lambdas

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ repositories {
 A biblioteca é composta de 3 modulos. Server, Client e Core.
 
 ```
- compile "br.com.guiabolso:events-client:2.4.0"
- compile "br.com.guiabolso:events-server:2.4.0"
- compile "br.com.guiabolso:events-core:2.4.0"
+ compile "br.com.guiabolso:events-client:2.5.0"
+ compile "br.com.guiabolso:events-server:2.5.0"
+ compile "br.com.guiabolso:events-core:2.5.0"
 ```
 Geralmente as dependências a serem importadas são:
 
@@ -54,7 +54,7 @@ Toda informação é transmitida utilizando um JSON padronizado com o seguinte f
 Qualquer comunicação entre sistemas é considerado um evento.
 
 #### Exemplo:
-```javascript
+```json
 {
 	"name": "some event",
 	"version": 42,
@@ -70,7 +70,7 @@ Qualquer comunicação entre sistemas é considerado um evento.
 	},
 	"auth": {
 		"token": "fk20f2p9o2v2l923"
-	}
+	},
 	"metadata": {
 		"origin": "Documentation",
 		"originId": "RFC-GB 0001",
@@ -132,7 +132,7 @@ Campos fixos no evento:
 
 #### Exemplo:
 
-```javascript
+```json
 {
 	"name": "some event:response",
 	"version": 1,
@@ -159,7 +159,7 @@ Campos fixos no evento:
 
 #### Exemplo:
 
-```javascript
+```json
 {
 	"name": "some:event:error",
 	"version": 1,
@@ -190,7 +190,7 @@ Indica que o request foi feito ao servidor de maneira incorreta. Provavelmente c
 
 #### Exemplo:
 
-```javascript
+```json
 {
 	"name": "some:event:bad_request",
 	"version": 1,
@@ -215,7 +215,7 @@ Indica que o cliente não está autorizado acessar aquela API no servidor. Prova
 
 #### Exemplo:
 
-```javascript
+```json
 {
 	"name": "some:event:unauthorized",
 	"version": 1,
@@ -239,7 +239,7 @@ Indica que o servidor não encontrou o recurso solicitado pelo cliente.
 
 #### Exemplo:
 
-```javascript
+```json
 {
 	"name": "some:event:not_found",
 	"version": 1,
@@ -263,7 +263,7 @@ Indica que o servidor impede o acesso a um recurso devido ser proibido por algum
 
 #### Exemplo:
 
-```javascript
+```json
 {
 	"name": "some:event:forbidden",
 	"version": 1,
@@ -287,15 +287,15 @@ Tipo padronizado para indicar que não foi possível responder com sucesso pois 
 
 #### Exemplo:
 
-```javascript
+```json
 {
 	"name": "some:event:failed_dependency",
 	"version": 1,
 	"id": "d8cab3c2-b15b-439b-ae5b-c8a96c61d637",
 	"flowId": "49689dcf-80c4-45a6-9f82-61a240e49a5c",
 	"payload": {
-		"code": "UNKNOWN_ERROR"
-		"message": "Anubis returned an error",
+		"code": "UNKNOWN_ERROR",
+		"message": "Anubis returned an error"
 	},
 	"metadata": {
 		"origin": "Ryzen",

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 allprojects {
     ext {
-        publish_version = '2.4.0'
+        publish_version = '2.5.0'
     }
 }
 

--- a/core/src/main/kotlin/br/com/guiabolso/events/validation/EventValidationException.kt
+++ b/core/src/main/kotlin/br/com/guiabolso/events/validation/EventValidationException.kt
@@ -1,0 +1,12 @@
+package br.com.guiabolso.events.validation
+
+import br.com.guiabolso.events.model.EventMessage
+
+class EventValidationException(propertyName: String) : RuntimeException() {
+
+    val eventMessage = EventMessage(
+        "INVALID_COMMUNICATION_PROTOCOL",
+        mapOf("missingProperty" to propertyName)
+    )
+
+}

--- a/core/src/main/kotlin/br/com/guiabolso/events/validation/EventValidator.kt
+++ b/core/src/main/kotlin/br/com/guiabolso/events/validation/EventValidator.kt
@@ -6,12 +6,12 @@ import br.com.guiabolso.events.model.ResponseEvent
 
 interface EventValidator {
 
-    fun validateAsResponseEvent(rawEvent: RawEvent): ResponseEvent
+    fun validateAsResponseEvent(rawEvent: RawEvent?): ResponseEvent
 
-    fun validateAsRequestEvent(rawEvent: RawEvent): RequestEvent
+    fun validateAsRequestEvent(rawEvent: RawEvent?): RequestEvent
 
     fun <T> T?.required(name: String) = when (this) {
-        null -> throw IllegalArgumentException(name)
+        null -> throw EventValidationException(name)
         else -> this
     }
 

--- a/core/src/main/kotlin/br/com/guiabolso/events/validation/LenientEventValidator.kt
+++ b/core/src/main/kotlin/br/com/guiabolso/events/validation/LenientEventValidator.kt
@@ -14,22 +14,22 @@ import org.slf4j.LoggerFactory
 )
 class LenientEventValidator : EventValidator {
 
-    override fun validateAsResponseEvent(rawEvent: RawEvent): ResponseEvent {
-        val name = rawEvent.name.required("name")
-        val version = rawEvent.version.required("version")
-        val flowId = rawEvent.flowId.required("flowId")
+    override fun validateAsResponseEvent(rawEvent: RawEvent?): ResponseEvent {
+        val name = rawEvent?.name.required("name")
+        val version = rawEvent?.version.required("version")
+        val flowId = rawEvent?.flowId.required("flowId")
 
         val missingProperties = mutableListOf<String>()
 
         val responseEvent = ResponseEvent(
             name = name,
             version = version,
-            id = rawEvent.id.required("id"),
+            id = rawEvent?.id.required("id"),
             flowId = flowId,
-            payload = rawEvent.payload.getPayload(missingProperties, "payload"),
-            identity = rawEvent.identity.getAsJsonObject(missingProperties, "identity"),
-            auth = rawEvent.auth.getAsJsonObject(missingProperties, "auth"),
-            metadata = rawEvent.metadata.getAsJsonObject(missingProperties, "metadata")
+            payload = rawEvent?.payload.getPayload(missingProperties, "payload"),
+            identity = rawEvent?.identity.getAsJsonObject(missingProperties, "identity"),
+            auth = rawEvent?.auth.getAsJsonObject(missingProperties, "auth"),
+            metadata = rawEvent?.metadata.getAsJsonObject(missingProperties, "metadata")
         )
 
         if (missingProperties.isNotEmpty()) {
@@ -39,22 +39,22 @@ class LenientEventValidator : EventValidator {
         return responseEvent
     }
 
-    override fun validateAsRequestEvent(rawEvent: RawEvent): RequestEvent {
-        val name = rawEvent.name.required("name")
-        val version = rawEvent.version.required("version")
-        val flowId = rawEvent.flowId.required("flowId")
+    override fun validateAsRequestEvent(rawEvent: RawEvent?): RequestEvent {
+        val name = rawEvent?.name.required("name")
+        val version = rawEvent?.version.required("version")
+        val flowId = rawEvent?.flowId.required("flowId")
 
         val missingProperties = mutableListOf<String>()
 
         val request = RequestEvent(
             name = name,
             version = version,
-            id = rawEvent.id.required("id"),
+            id = rawEvent?.id.required("id"),
             flowId = flowId,
-            payload = rawEvent.payload.getPayload(missingProperties, "payload"),
-            identity = rawEvent.identity.getAsJsonObject(missingProperties, "identity"),
-            auth = rawEvent.auth.getAsJsonObject(missingProperties, "auth"),
-            metadata = rawEvent.metadata.getAsJsonObject(missingProperties, "metadata")
+            payload = rawEvent?.payload.getPayload(missingProperties, "payload"),
+            identity = rawEvent?.identity.getAsJsonObject(missingProperties, "identity"),
+            auth = rawEvent?.auth.getAsJsonObject(missingProperties, "auth"),
+            metadata = rawEvent?.metadata.getAsJsonObject(missingProperties, "metadata")
         )
 
         if (missingProperties.isNotEmpty()) {

--- a/core/src/main/kotlin/br/com/guiabolso/events/validation/StrictEventValidator.kt
+++ b/core/src/main/kotlin/br/com/guiabolso/events/validation/StrictEventValidator.kt
@@ -8,30 +8,30 @@ import com.google.gson.JsonObject
 
 class StrictEventValidator : EventValidator {
 
-    override fun validateAsResponseEvent(rawEvent: RawEvent) = ResponseEvent(
-        name = rawEvent.name.required("name"),
-        version = rawEvent.version.required("version"),
-        id = rawEvent.id.required("id"),
-        flowId = rawEvent.flowId.required("flowId"),
-        payload = rawEvent.payload.required("payload"),
-        identity = rawEvent.identity.requiredJsonObject("identity"),
-        auth = rawEvent.auth.requiredJsonObject("auth"),
-        metadata = rawEvent.metadata.requiredJsonObject("metadata")
+    override fun validateAsResponseEvent(rawEvent: RawEvent?) = ResponseEvent(
+        name = rawEvent?.name.required("name"),
+        version = rawEvent?.version.required("version"),
+        id = rawEvent?.id.required("id"),
+        flowId = rawEvent?.flowId.required("flowId"),
+        payload = rawEvent?.payload.required("payload"),
+        identity = rawEvent?.identity.requiredJsonObject("identity"),
+        auth = rawEvent?.auth.requiredJsonObject("auth"),
+        metadata = rawEvent?.metadata.requiredJsonObject("metadata")
     )
 
-    override fun validateAsRequestEvent(rawEvent: RawEvent) = RequestEvent(
-        name = rawEvent.name.required("name"),
-        version = rawEvent.version.required("version"),
-        id = rawEvent.id.required("id"),
-        flowId = rawEvent.flowId.required("flowId"),
-        payload = rawEvent.payload.required("payload"),
-        identity = rawEvent.identity.requiredJsonObject("identity"),
-        auth = rawEvent.auth.requiredJsonObject("auth"),
-        metadata = rawEvent.metadata.requiredJsonObject("metadata")
+    override fun validateAsRequestEvent(rawEvent: RawEvent?) = RequestEvent(
+        name = rawEvent?.name.required("name"),
+        version = rawEvent?.version.required("version"),
+        id = rawEvent?.id.required("id"),
+        flowId = rawEvent?.flowId.required("flowId"),
+        payload = rawEvent?.payload.required("payload"),
+        identity = rawEvent?.identity.requiredJsonObject("identity"),
+        auth = rawEvent?.auth.requiredJsonObject("auth"),
+        metadata = rawEvent?.metadata.requiredJsonObject("metadata")
     )
 
     private fun JsonElement?.requiredJsonObject(name: String): JsonObject {
-        if (this == null || !this.isJsonObject) throw IllegalArgumentException(name)
+        if (this == null || !this.isJsonObject) throw EventValidationException(name)
         return this.asJsonObject
     }
 

--- a/core/src/test/kotlin/br/com/guiabolso/events/EventBuilderForTest.kt
+++ b/core/src/test/kotlin/br/com/guiabolso/events/EventBuilderForTest.kt
@@ -1,6 +1,5 @@
 package br.com.guiabolso.events
 
-import br.com.guiabolso.events.json.MapperHolder
 import br.com.guiabolso.events.model.RawEvent
 import br.com.guiabolso.events.model.RequestEvent
 import br.com.guiabolso.events.model.ResponseEvent
@@ -55,8 +54,5 @@ object EventBuilderForTest {
         auth = JsonObject(),
         metadata = JsonObject()
     )
-
-    fun buildRequestEventString(event: RequestEvent = buildRequestEvent()) =
-        MapperHolder.mapper.toJson(event)!!
 
 }

--- a/core/src/test/kotlin/br/com/guiabolso/events/EventBuilderForTest.kt
+++ b/core/src/test/kotlin/br/com/guiabolso/events/EventBuilderForTest.kt
@@ -1,12 +1,24 @@
 package br.com.guiabolso.events
 
 import br.com.guiabolso.events.json.MapperHolder
+import br.com.guiabolso.events.model.RawEvent
 import br.com.guiabolso.events.model.RequestEvent
 import br.com.guiabolso.events.model.ResponseEvent
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 
 object EventBuilderForTest {
+
+    fun buildRawRequestEvent() = RawEvent(
+        name = "event:name",
+        version = 1,
+        id = "id",
+        flowId = "flowId",
+        payload = JsonPrimitive(42),
+        identity = JsonObject(),
+        auth = JsonObject(),
+        metadata = JsonObject()
+    )
 
     fun buildRequestEvent() = RequestEvent(
         name = "event:name",
@@ -43,7 +55,6 @@ object EventBuilderForTest {
         auth = JsonObject(),
         metadata = JsonObject()
     )
-
 
     fun buildRequestEventString(event: RequestEvent = buildRequestEvent()) =
         MapperHolder.mapper.toJson(event)!!

--- a/core/src/test/kotlin/br/com/guiabolso/events/validation/LenientEventValidatorTest.kt
+++ b/core/src/test/kotlin/br/com/guiabolso/events/validation/LenientEventValidatorTest.kt
@@ -30,7 +30,7 @@ class LenientEventValidatorTest {
 
     @Test
     fun testResponseValidationWithoutName() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsResponseEvent(
                 RawEvent(
                     null,
@@ -48,7 +48,7 @@ class LenientEventValidatorTest {
 
     @Test
     fun testResponseValidationWithoutVersion() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsResponseEvent(
                 RawEvent(
                     "event",
@@ -66,7 +66,7 @@ class LenientEventValidatorTest {
 
     @Test
     fun testResponseValidationWithoutId() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsResponseEvent(
                 RawEvent(
                     "event",
@@ -219,7 +219,7 @@ class LenientEventValidatorTest {
 
     @Test
     fun testRequestValidationWithoutName() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     null,
@@ -237,7 +237,7 @@ class LenientEventValidatorTest {
 
     @Test
     fun testRequestValidationWithoutVersion() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     "event",
@@ -255,7 +255,7 @@ class LenientEventValidatorTest {
 
     @Test
     fun testRequestValidationWithoutId() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     "event",
@@ -273,7 +273,7 @@ class LenientEventValidatorTest {
 
     @Test
     fun testRequestValidationWithoutFlowId() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     "event",

--- a/core/src/test/kotlin/br/com/guiabolso/events/validation/StrictEventValidatorTest.kt
+++ b/core/src/test/kotlin/br/com/guiabolso/events/validation/StrictEventValidatorTest.kt
@@ -29,7 +29,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testResponseValidationWithoutName() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsResponseEvent(
                 RawEvent(
                     null,
@@ -47,7 +47,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testResponseValidationWithoutVersion() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsResponseEvent(
                 RawEvent(
                     "event",
@@ -65,7 +65,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testResponseValidationWithoutId() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsResponseEvent(
                 RawEvent(
                     "event",
@@ -83,7 +83,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testResponseValidationWithoutPayload() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsResponseEvent(
                 RawEvent(
                     "event",
@@ -113,7 +113,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testResponseValidationWithoutIdentity() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsResponseEvent(
                 RawEvent(
                     "event",
@@ -127,7 +127,7 @@ class StrictEventValidatorTest {
                 )
             )
         }
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsResponseEvent(
                 RawEvent(
                     "event",
@@ -145,7 +145,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testResponseValidationWithoutAuth() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsResponseEvent(
                 RawEvent(
                     "event",
@@ -159,7 +159,7 @@ class StrictEventValidatorTest {
                 )
             )
         }
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsResponseEvent(
                 RawEvent(
                     "event",
@@ -177,7 +177,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testResponseValidationWithoutMetadata() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsResponseEvent(
                 RawEvent(
                     "event",
@@ -191,7 +191,7 @@ class StrictEventValidatorTest {
                 )
             )
         }
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsResponseEvent(
                 RawEvent(
                     "event",
@@ -224,7 +224,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testRequestValidationWithoutName() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     null,
@@ -242,7 +242,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testRequestValidationWithoutVersion() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     "event",
@@ -260,7 +260,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testRequestValidationWithoutId() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     "event",
@@ -278,7 +278,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testRequestValidationWithoutFlowId() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     "event",
@@ -296,7 +296,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testRequestValidationWithoutPayload() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     "event",
@@ -326,7 +326,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testRequestValidationWithoutIdentity() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     "event",
@@ -340,7 +340,7 @@ class StrictEventValidatorTest {
                 )
             )
         }
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     "event",
@@ -358,7 +358,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testRequestValidationWithoutAuth() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     "event",
@@ -372,7 +372,7 @@ class StrictEventValidatorTest {
                 )
             )
         }
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     "event",
@@ -390,7 +390,7 @@ class StrictEventValidatorTest {
 
     @Test
     fun testRequestValidationWithoutMetadata() {
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     "event",
@@ -404,7 +404,7 @@ class StrictEventValidatorTest {
                 )
             )
         }
-        assertThrows(IllegalArgumentException::class.java) {
+        assertThrows(EventValidationException::class.java) {
             validator.validateAsRequestEvent(
                 RawEvent(
                     "event",

--- a/server/src/main/kotlin/br/com/guiabolso/events/server/AWSLambdaEventProcessor.kt
+++ b/server/src/main/kotlin/br/com/guiabolso/events/server/AWSLambdaEventProcessor.kt
@@ -45,7 +45,7 @@ constructor(
         try {
             val lambdaBody = MapperHolder.mapper.fromJson(payload, LambdaRequest::class.java)?.body ?: return null
             return MapperHolder.mapper.fromJson(lambdaBody, RawEvent::class.java)
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             throw EventParsingException(e)
         }
     }

--- a/server/src/main/kotlin/br/com/guiabolso/events/server/AWSLambdaEventProcessor.kt
+++ b/server/src/main/kotlin/br/com/guiabolso/events/server/AWSLambdaEventProcessor.kt
@@ -1,0 +1,80 @@
+package br.com.guiabolso.events.server
+
+import br.com.guiabolso.events.builder.EventBuilder.Companion.badProtocol
+import br.com.guiabolso.events.json.MapperHolder
+import br.com.guiabolso.events.model.RawEvent
+import br.com.guiabolso.events.model.ResponseEvent
+import br.com.guiabolso.events.server.exception.ExceptionHandlerRegistry
+import br.com.guiabolso.events.server.handler.EventHandlerDiscovery
+import br.com.guiabolso.events.server.parser.EventParsingException
+import br.com.guiabolso.events.validation.EventValidator
+import br.com.guiabolso.events.validation.StrictEventValidator
+import br.com.guiabolso.tracing.Tracer
+import br.com.guiabolso.tracing.factory.TracerFactory
+import java.io.BufferedReader
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStream
+
+class AWSLambdaEventProcessor
+@JvmOverloads
+constructor(
+    discovery: EventHandlerDiscovery,
+    exceptionHandlerRegistry: ExceptionHandlerRegistry,
+    private val tracer: Tracer = TracerFactory.createTracer(),
+    eventValidator: EventValidator = StrictEventValidator()
+) {
+
+    private val eventProcessor = RawEventProcessor(discovery, exceptionHandlerRegistry, tracer, eventValidator)
+
+    fun processEvent(input: InputStream, output: OutputStream) {
+        val payload = readInput(input)
+
+        val response = try {
+            val rawEvent = parseEvent(payload)
+            eventProcessor.processEvent(rawEvent)
+        } catch (e: EventParsingException) {
+            tracer.notifyError(e, false)
+            badProtocol(e.eventMessage)
+        }
+
+        writeOutput(output, response.json())
+    }
+
+    private fun parseEvent(payload: String?): RawEvent? {
+        try {
+            val lambdaBody = MapperHolder.mapper.fromJson(payload, LambdaRequest::class.java)?.body ?: return null
+            return MapperHolder.mapper.fromJson(lambdaBody, RawEvent::class.java)
+        } catch (e: Exception) {
+            throw EventParsingException(e)
+        }
+    }
+
+    private fun readInput(input: InputStream): String {
+        val reader = BufferedReader(InputStreamReader(input))
+        return reader.use { reader.readText() }
+    }
+
+    private fun writeOutput(output: OutputStream, response: String) {
+        output.use { it.write(response.toByteArray()) }
+    }
+
+    private fun ResponseEvent.json() = MapperHolder.mapper.toJson(
+        LambdaResponse(
+            statusCode = 200,
+            headers = mapOf("Content-Type" to "application/json"),
+            body = MapperHolder.mapper.toJson(this)
+        )
+    )
+
+    private data class LambdaRequest(
+        val body: String?
+    )
+
+    private data class LambdaResponse(
+        val statusCode: Int,
+        val headers: Map<String, String>,
+        val body: String
+    )
+
+}

--- a/server/src/main/kotlin/br/com/guiabolso/events/server/AWSLambdaEventProcessor.kt
+++ b/server/src/main/kotlin/br/com/guiabolso/events/server/AWSLambdaEventProcessor.kt
@@ -11,9 +11,7 @@ import br.com.guiabolso.events.validation.EventValidator
 import br.com.guiabolso.events.validation.StrictEventValidator
 import br.com.guiabolso.tracing.Tracer
 import br.com.guiabolso.tracing.factory.TracerFactory
-import java.io.BufferedReader
 import java.io.InputStream
-import java.io.InputStreamReader
 import java.io.OutputStream
 
 class AWSLambdaEventProcessor
@@ -51,8 +49,7 @@ constructor(
     }
 
     private fun readInput(input: InputStream): String {
-        val reader = BufferedReader(InputStreamReader(input))
-        return reader.use { reader.readText() }
+        return input.bufferedReader(Charsets.UTF_8).use { it.readText() }
     }
 
     private fun writeOutput(output: OutputStream, response: String) {

--- a/server/src/main/kotlin/br/com/guiabolso/events/server/EventProcessor.kt
+++ b/server/src/main/kotlin/br/com/guiabolso/events/server/EventProcessor.kt
@@ -1,18 +1,12 @@
 package br.com.guiabolso.events.server
 
 import br.com.guiabolso.events.builder.EventBuilder.Companion.badProtocol
-import br.com.guiabolso.events.builder.EventBuilder.Companion.eventNotFound
-import br.com.guiabolso.events.context.EventContext
-import br.com.guiabolso.events.context.EventContextHolder
 import br.com.guiabolso.events.json.MapperHolder
-import br.com.guiabolso.events.model.Event
-import br.com.guiabolso.events.model.EventMessage
 import br.com.guiabolso.events.model.RawEvent
-import br.com.guiabolso.events.model.RequestEvent
 import br.com.guiabolso.events.model.ResponseEvent
 import br.com.guiabolso.events.server.exception.ExceptionHandlerRegistry
-import br.com.guiabolso.events.server.exception.ExceptionHandlerRegistryFactory.bypassExceptionHandler
 import br.com.guiabolso.events.server.handler.EventHandlerDiscovery
+import br.com.guiabolso.events.server.parser.EventParsingException
 import br.com.guiabolso.events.validation.EventValidator
 import br.com.guiabolso.events.validation.StrictEventValidator
 import br.com.guiabolso.tracing.Tracer
@@ -21,99 +15,32 @@ import br.com.guiabolso.tracing.factory.TracerFactory
 class EventProcessor
 @JvmOverloads
 constructor(
-    private val discovery: EventHandlerDiscovery,
-    private val exceptionHandlerRegistry: ExceptionHandlerRegistry,
+    discovery: EventHandlerDiscovery,
+    exceptionHandlerRegistry: ExceptionHandlerRegistry,
     private val tracer: Tracer = TracerFactory.createTracer(),
-    private val eventValidator: EventValidator = StrictEventValidator()
+    eventValidator: EventValidator = StrictEventValidator()
 ) {
 
-    @JvmOverloads
-    @Deprecated(
-        "The 'exposeExceptions' should not be used. Use 'ExceptionHandlerRegistryFactory.bypassExceptionHandler()' as exception handler instead.",
-        ReplaceWith(
-            "EventProcessor(discovery, ExceptionHandlerRegistryFactory.bypassExceptionHandler(), eventValidator, tracer)",
-            "br.com.guiabolso.events.server.exception.ExceptionHandlerRegistryFactory"
-        )
-    )
-    constructor(
-        discovery: EventHandlerDiscovery,
-        exceptionHandlerRegistry: ExceptionHandlerRegistry,
-        tracer: Tracer = TracerFactory.createTracer(),
-        eventValidator: EventValidator = StrictEventValidator(),
-        exposeExceptions: Boolean
-    ) : this(discovery, configureExceptionHandler(exceptionHandlerRegistry, exposeExceptions), tracer, eventValidator)
+    private val eventProcessor = RawEventProcessor(discovery, exceptionHandlerRegistry, tracer, eventValidator)
 
-    fun processEvent(rawEvent: String): String {
-        return when (val event = parseAndValidateEvent(rawEvent)) {
-            is RequestEvent -> {
-                val handler = discovery.eventHandlerFor(event.name, event.version)
-                return if (handler == null) {
-                    eventNotFound(event).json()
-                } else {
-                    try {
-                        EventContextHolder.setContext(EventContext(event.id, event.flowId))
-                        startProcessingEvent(event)
-                        handler.handle(event).json()
-                    } catch (e: Exception) {
-                        exceptionHandlerRegistry.handleException(e, event, tracer).json()
-                    } finally {
-                        EventContextHolder.clean()
-                        eventProcessFinished()
-                    }
-                }
-            }
-            is ResponseEvent -> event.json()
+    fun processEvent(payload: String?): String {
+        return try {
+            val rawEvent = parseEvent(payload)
+            eventProcessor.processEvent(rawEvent).json()
+        } catch (e: EventParsingException) {
+            tracer.notifyError(e, false)
+            badProtocol(e.eventMessage).json()
         }
     }
 
-    private fun parseAndValidateEvent(rawEvent: String): Event =
+    private fun parseEvent(payload: String?): RawEvent? {
         try {
-            val input = MapperHolder.mapper.fromJson(rawEvent, RawEvent::class.java)
-            eventValidator.validateAsRequestEvent(input)
-        } catch (e: IllegalArgumentException) {
-            tracer.notifyError(e, false)
-            badProtocol(
-                EventMessage(
-                    "INVALID_COMMUNICATION_PROTOCOL",
-                    mapOf("missingProperty" to e.message)
-                )
-            )
+            return MapperHolder.mapper.fromJson(payload, RawEvent::class.java)
         } catch (e: Exception) {
-            tracer.notifyError(e, false)
-            badProtocol(
-                EventMessage(
-                    "INVALID_COMMUNICATION_PROTOCOL",
-                    mapOf("message" to e.message)
-                )
-            )
+            throw EventParsingException(e)
         }
-
-    private fun startProcessingEvent(event: RequestEvent) {
-        tracer.setOperationName("${event.name}:V${event.version}")
-        tracer.addProperty("EventID", event.id)
-        tracer.addProperty("FlowID", event.flowId)
-        tracer.addProperty("UserID", event.userId?.toString() ?: "unknown")
-        tracer.addProperty("Origin", event.origin ?: "unknown")
-    }
-
-    private fun eventProcessFinished() {
-        tracer.clear()
     }
 
     private fun ResponseEvent.json() = MapperHolder.mapper.toJson(this)
 
-    companion object {
-
-        private fun configureExceptionHandler(
-            handler: ExceptionHandlerRegistry,
-            exposeExceptions: Boolean
-        ): ExceptionHandlerRegistry {
-            return if (exposeExceptions) {
-                bypassExceptionHandler(false)
-            } else {
-                handler
-            }
-        }
-
-    }
 }

--- a/server/src/main/kotlin/br/com/guiabolso/events/server/EventProcessor.kt
+++ b/server/src/main/kotlin/br/com/guiabolso/events/server/EventProcessor.kt
@@ -36,7 +36,7 @@ constructor(
     private fun parseEvent(payload: String?): RawEvent? {
         try {
             return MapperHolder.mapper.fromJson(payload, RawEvent::class.java)
-        } catch (e: Exception) {
+        } catch (e: Throwable) {
             throw EventParsingException(e)
         }
     }

--- a/server/src/main/kotlin/br/com/guiabolso/events/server/RawEventProcessor.kt
+++ b/server/src/main/kotlin/br/com/guiabolso/events/server/RawEventProcessor.kt
@@ -1,0 +1,71 @@
+package br.com.guiabolso.events.server
+
+import br.com.guiabolso.events.builder.EventBuilder.Companion.badProtocol
+import br.com.guiabolso.events.builder.EventBuilder.Companion.eventNotFound
+import br.com.guiabolso.events.context.EventContext
+import br.com.guiabolso.events.context.EventContextHolder
+import br.com.guiabolso.events.model.Event
+import br.com.guiabolso.events.model.RawEvent
+import br.com.guiabolso.events.model.RequestEvent
+import br.com.guiabolso.events.model.ResponseEvent
+import br.com.guiabolso.events.server.exception.ExceptionHandlerRegistry
+import br.com.guiabolso.events.server.handler.EventHandlerDiscovery
+import br.com.guiabolso.events.validation.EventValidationException
+import br.com.guiabolso.events.validation.EventValidator
+import br.com.guiabolso.events.validation.StrictEventValidator
+import br.com.guiabolso.tracing.Tracer
+import br.com.guiabolso.tracing.factory.TracerFactory
+
+class RawEventProcessor
+@JvmOverloads
+constructor(
+    private val discovery: EventHandlerDiscovery,
+    private val exceptionHandlerRegistry: ExceptionHandlerRegistry,
+    private val tracer: Tracer = TracerFactory.createTracer(),
+    private val eventValidator: EventValidator = StrictEventValidator()
+) {
+
+    fun processEvent(rawEvent: RawEvent?): ResponseEvent {
+        return when (val event = validateEvent(rawEvent)) {
+            is RequestEvent -> {
+                val handler = discovery.eventHandlerFor(event.name, event.version)
+                return if (handler == null) {
+                    eventNotFound(event)
+                } else {
+                    try {
+                        EventContextHolder.setContext(EventContext(event.id, event.flowId))
+                        startProcessingEvent(event)
+                        handler.handle(event)
+                    } catch (e: Exception) {
+                        exceptionHandlerRegistry.handleException(e, event, tracer)
+                    } finally {
+                        EventContextHolder.clean()
+                        eventProcessFinished()
+                    }
+                }
+            }
+            is ResponseEvent -> event
+        }
+    }
+
+    private fun validateEvent(rawEvent: RawEvent?): Event =
+        try {
+            eventValidator.validateAsRequestEvent(rawEvent)
+        } catch (e: EventValidationException) {
+            tracer.notifyError(e, false)
+            badProtocol(e.eventMessage)
+        }
+
+    private fun startProcessingEvent(event: RequestEvent) {
+        tracer.setOperationName("${event.name}:V${event.version}")
+        tracer.addProperty("EventID", event.id)
+        tracer.addProperty("FlowID", event.flowId)
+        tracer.addProperty("UserID", event.userId?.toString() ?: "unknown")
+        tracer.addProperty("Origin", event.origin ?: "unknown")
+    }
+
+    private fun eventProcessFinished() {
+        tracer.clear()
+    }
+
+}

--- a/server/src/main/kotlin/br/com/guiabolso/events/server/parser/EventParsingException.kt
+++ b/server/src/main/kotlin/br/com/guiabolso/events/server/parser/EventParsingException.kt
@@ -1,0 +1,11 @@
+package br.com.guiabolso.events.server.parser
+
+import br.com.guiabolso.events.model.EventMessage
+
+
+class EventParsingException(cause: Throwable) : RuntimeException(cause.message, cause) {
+    val eventMessage: EventMessage = EventMessage(
+        "INVALID_COMMUNICATION_PROTOCOL",
+        mapOf("message" to cause.message)
+    )
+}

--- a/server/src/test/kotlin/br/com/guiabolso/events/server/AWSLambdaEventProcessorTest.kt
+++ b/server/src/test/kotlin/br/com/guiabolso/events/server/AWSLambdaEventProcessorTest.kt
@@ -1,0 +1,73 @@
+package br.com.guiabolso.events.server
+
+import br.com.guiabolso.events.EventBuilderForTest.buildRequestEvent
+import br.com.guiabolso.events.EventBuilderForTest.buildResponseEvent
+import br.com.guiabolso.events.json.MapperHolder
+import br.com.guiabolso.events.model.RawEvent
+import br.com.guiabolso.events.model.RequestEvent
+import br.com.guiabolso.events.server.exception.ExceptionHandlerRegistry
+import br.com.guiabolso.events.server.handler.SimpleEventHandlerRegistry
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+
+class AWSLambdaEventProcessorTest {
+
+    private lateinit var lambdaEventProcessor: AWSLambdaEventProcessor
+    private lateinit var eventHandlerRegistry: SimpleEventHandlerRegistry
+    private lateinit var exceptionHandlerRegistry: ExceptionHandlerRegistry
+
+    @BeforeEach
+    fun setUp() {
+        eventHandlerRegistry = SimpleEventHandlerRegistry()
+        exceptionHandlerRegistry = ExceptionHandlerRegistry()
+        lambdaEventProcessor = AWSLambdaEventProcessor(eventHandlerRegistry, exceptionHandlerRegistry)
+    }
+
+    @Test
+    fun testCanProcessEvent() {
+        val event = buildRequestEvent()
+
+        eventHandlerRegistry.add(event.name, event.version) {
+            buildResponseEvent()
+        }
+
+        val input = buildLambdaRequestEventString().asStream()
+        val output = ByteArrayOutputStream()
+        lambdaEventProcessor.processEvent(input, output)
+
+        val lambdaBody = MapperHolder.mapper.fromJson(String(output.toByteArray()), JsonObject::class.java).get("body").asString
+        val responseEvent = MapperHolder.mapper.fromJson(lambdaBody, RawEvent::class.java)
+
+        assertEquals("event:name:response", responseEvent.name)
+        assertEquals(1, responseEvent.version)
+        assertEquals(42, responseEvent.payload?.asInt)
+    }
+
+    @Test
+    fun testBadProtocolEventIsReturned() {
+        val input = "{\"body\":\"THIS IS NOT A EVENT\"}".asStream()
+        val output = ByteArrayOutputStream()
+        lambdaEventProcessor.processEvent(input, output)
+
+        val lambdaBody = MapperHolder.mapper.fromJson(String(output.toByteArray()), JsonObject::class.java).get("body").asString
+        val responseEvent = MapperHolder.mapper.fromJson(lambdaBody, RawEvent::class.java)
+
+        assertEquals("badProtocol", responseEvent.name)
+        assertEquals(1, responseEvent.version)
+        assertEquals("INVALID_COMMUNICATION_PROTOCOL", responseEvent.payload!!.asJsonObject.get("code").asString)
+    }
+
+    private fun buildLambdaRequestEventString(event: RequestEvent = buildRequestEvent()) = MapperHolder.mapper.toJson(
+        JsonObject().apply {
+            add("body", JsonPrimitive(MapperHolder.mapper.toJson(event)!!))
+        }
+    )!!
+
+    private fun String.asStream() = ByteArrayInputStream(this.toByteArray())
+
+}

--- a/server/src/test/kotlin/br/com/guiabolso/events/server/EventProcessorTest.kt
+++ b/server/src/test/kotlin/br/com/guiabolso/events/server/EventProcessorTest.kt
@@ -1,6 +1,8 @@
 package br.com.guiabolso.events.server
 
-import br.com.guiabolso.events.EventBuilderForTest
+import br.com.guiabolso.events.EventBuilderForTest.buildRequestEvent
+import br.com.guiabolso.events.EventBuilderForTest.buildRequestEventString
+import br.com.guiabolso.events.EventBuilderForTest.buildResponseEvent
 import br.com.guiabolso.events.json.MapperHolder
 import br.com.guiabolso.events.model.RawEvent
 import br.com.guiabolso.events.server.exception.ExceptionHandlerRegistry
@@ -13,7 +15,7 @@ import org.junit.jupiter.api.Test
 
 class EventProcessorTest {
 
-    private lateinit var eventProcessor: EventProcessor
+    private lateinit var rawEventProcessor: EventProcessor
     private lateinit var eventHandlerRegistry: SimpleEventHandlerRegistry
     private lateinit var exceptionHandlerRegistry: ExceptionHandlerRegistry
     private lateinit var tracer: Tracer
@@ -23,18 +25,18 @@ class EventProcessorTest {
         eventHandlerRegistry = SimpleEventHandlerRegistry()
         exceptionHandlerRegistry = ExceptionHandlerRegistry()
         tracer = mock()
-        eventProcessor = EventProcessor(eventHandlerRegistry, exceptionHandlerRegistry)
+        rawEventProcessor = EventProcessor(eventHandlerRegistry, exceptionHandlerRegistry)
     }
 
     @Test
     fun testCanProcessEvent() {
-        val event = EventBuilderForTest.buildRequestEvent()
+        val event = buildRequestEvent()
 
         eventHandlerRegistry.add(event.name, event.version) {
-            EventBuilderForTest.buildResponseEvent()
+            buildResponseEvent()
         }
 
-        val responseEvent = eventProcessor.processEvent(EventBuilderForTest.buildRequestEventString())
+        val responseEvent = rawEventProcessor.processEvent(buildRequestEventString())
 
         assertEquals(
             "{\"name\":\"event:name:response\",\"version\":1,\"id\":\"id\",\"flowId\":\"flowId\",\"payload\":42,\"identity\":{},\"auth\":{},\"metadata\":{}}",
@@ -43,83 +45,13 @@ class EventProcessorTest {
     }
 
     @Test
-    fun testEventNotFound() {
-        val responseEvent = eventProcessor.processEvent(EventBuilderForTest.buildRequestEventString())
-
-        assertEquals(
-            "{\"name\":\"eventNotFound\",\"version\":1,\"id\":\"id\",\"flowId\":\"flowId\",\"payload\":{\"code\":\"NO_EVENT_HANDLER_FOUND\",\"parameters\":{\"event\":\"event:name\",\"version\":1}},\"identity\":{},\"auth\":{},\"metadata\":{}}",
-            responseEvent
-        )
-    }
-
-    @Test
-    fun testEventThrowException() {
-        val event = EventBuilderForTest.buildRequestEvent()
-
-        eventHandlerRegistry.add(event.name, event.version) {
-            throw RuntimeException("error")
-        }
-
-        val responseEvent = MapperHolder.mapper.fromJson(
-            eventProcessor.processEvent(EventBuilderForTest.buildRequestEventString()),
-            RawEvent::class.java
-        )
-
-        assertEquals("${event.name}:error", responseEvent.name)
-        assertEquals("UNHANDLED_ERROR", responseEvent.payload!!.asJsonObject["code"].asString)
-    }
-
-    @Test
-    fun testCanHandleException() {
-        val event = EventBuilderForTest.buildRequestEvent()
-
-        eventHandlerRegistry.add(event.name, event.version) {
-            throw RuntimeException("error")
-        }
-
-        exceptionHandlerRegistry.register(RuntimeException::class.java) { _, requestEvent, _ ->
-            EventBuilderForTest.buildResponseEvent().copy("${requestEvent.name}:bad_request")
-        }
-
-        val responseEvent = MapperHolder.mapper.fromJson(
-            eventProcessor.processEvent(EventBuilderForTest.buildRequestEventString()),
-            RawEvent::class.java
-        )
-
-        assertEquals("${event.name}:bad_request", responseEvent.name)
-    }
-
-    @Test
     fun testBadProtocolEventIsReturned() {
         val responseEvent =
-            MapperHolder.mapper.fromJson(eventProcessor.processEvent("THIS IS NOT A EVENT"), RawEvent::class.java)
+            MapperHolder.mapper.fromJson(rawEventProcessor.processEvent("THIS IS NOT A EVENT"), RawEvent::class.java)
 
         assertEquals("badProtocol", responseEvent.name)
         assertEquals("INVALID_COMMUNICATION_PROTOCOL", responseEvent.payload!!.asJsonObject["code"].asString)
     }
 
-    @Test
-    fun testBadProtocolEventIsReturnedWhenParameterIsMissing() {
-
-        val eventWithoutVersion = """
-            {
-              "name": "event:name",
-              "id": "sjfid",
-              "flowId": "dsókf0sd",
-              "payload":{},
-              "metadata": {}
-            }
-        """.trimIndent()
-
-        val responseEvent =
-            MapperHolder.mapper.fromJson(eventProcessor.processEvent(eventWithoutVersion), RawEvent::class.java)
-
-        assertEquals("badProtocol", responseEvent.name)
-        assertEquals("INVALID_COMMUNICATION_PROTOCOL", responseEvent.payload!!.asJsonObject["code"].asString)
-        assertEquals(
-            "version",
-            responseEvent.payload!!.asJsonObject["parameters"].asJsonObject["missingProperty"].asString
-        )
-    }
 
 }

--- a/server/src/test/kotlin/br/com/guiabolso/events/server/EventProcessorTest.kt
+++ b/server/src/test/kotlin/br/com/guiabolso/events/server/EventProcessorTest.kt
@@ -1,14 +1,12 @@
 package br.com.guiabolso.events.server
 
 import br.com.guiabolso.events.EventBuilderForTest.buildRequestEvent
-import br.com.guiabolso.events.EventBuilderForTest.buildRequestEventString
 import br.com.guiabolso.events.EventBuilderForTest.buildResponseEvent
 import br.com.guiabolso.events.json.MapperHolder
 import br.com.guiabolso.events.model.RawEvent
+import br.com.guiabolso.events.model.RequestEvent
 import br.com.guiabolso.events.server.exception.ExceptionHandlerRegistry
 import br.com.guiabolso.events.server.handler.SimpleEventHandlerRegistry
-import br.com.guiabolso.tracing.Tracer
-import com.nhaarman.mockito_kotlin.mock
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,13 +16,11 @@ class EventProcessorTest {
     private lateinit var rawEventProcessor: EventProcessor
     private lateinit var eventHandlerRegistry: SimpleEventHandlerRegistry
     private lateinit var exceptionHandlerRegistry: ExceptionHandlerRegistry
-    private lateinit var tracer: Tracer
 
     @BeforeEach
     fun setUp() {
         eventHandlerRegistry = SimpleEventHandlerRegistry()
         exceptionHandlerRegistry = ExceptionHandlerRegistry()
-        tracer = mock()
         rawEventProcessor = EventProcessor(eventHandlerRegistry, exceptionHandlerRegistry)
     }
 
@@ -53,5 +49,7 @@ class EventProcessorTest {
         assertEquals("INVALID_COMMUNICATION_PROTOCOL", responseEvent.payload!!.asJsonObject["code"].asString)
     }
 
+    private fun buildRequestEventString(event: RequestEvent = buildRequestEvent()) =
+        MapperHolder.mapper.toJson(event)!!
 
 }

--- a/server/src/test/kotlin/br/com/guiabolso/events/server/RawEventProcessorTest.kt
+++ b/server/src/test/kotlin/br/com/guiabolso/events/server/RawEventProcessorTest.kt
@@ -1,0 +1,102 @@
+package br.com.guiabolso.events.server
+
+import br.com.guiabolso.events.EventBuilderForTest.buildRawRequestEvent
+import br.com.guiabolso.events.EventBuilderForTest.buildResponseEvent
+import br.com.guiabolso.events.server.exception.ExceptionHandlerRegistry
+import br.com.guiabolso.events.server.handler.SimpleEventHandlerRegistry
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+class RawEventProcessorTest {
+
+    private lateinit var rawEventProcessor: RawEventProcessor
+    private lateinit var eventHandlerRegistry: SimpleEventHandlerRegistry
+    private lateinit var exceptionHandlerRegistry: ExceptionHandlerRegistry
+
+    @BeforeEach
+    fun setUp() {
+        eventHandlerRegistry = SimpleEventHandlerRegistry()
+        exceptionHandlerRegistry = ExceptionHandlerRegistry()
+        rawEventProcessor = RawEventProcessor(eventHandlerRegistry, exceptionHandlerRegistry)
+    }
+
+    @Test
+    fun testCanProcessEvent() {
+        val event = buildRawRequestEvent()
+        val expectedResponse = buildResponseEvent()
+
+        eventHandlerRegistry.add(event.name!!, event.version!!) {
+            expectedResponse
+        }
+
+        val responseEvent = rawEventProcessor.processEvent(event)
+
+        assertEquals(expectedResponse, responseEvent)
+    }
+
+    @Test
+    fun testEventNotFound() {
+        val responseEvent = rawEventProcessor.processEvent(buildRawRequestEvent())
+
+        assertEquals("id", responseEvent.id)
+        assertEquals("flowId", responseEvent.flowId)
+        assertEquals("eventNotFound", responseEvent.name)
+        assertEquals(1, responseEvent.version)
+        assertEquals("NO_EVENT_HANDLER_FOUND", responseEvent.payload.asJsonObject.get("code").asString)
+        val parameters = responseEvent.payload.asJsonObject.get("parameters").asJsonObject
+        assertEquals("event:name", parameters.get("event").asString)
+        assertEquals(1, parameters.get("version").asInt)
+    }
+
+    @Test
+    fun testEventThrowException() {
+        val event = buildRawRequestEvent()
+
+        eventHandlerRegistry.add(event.name!!, event.version!!) {
+            throw RuntimeException("error")
+        }
+
+        val responseEvent = rawEventProcessor.processEvent(buildRawRequestEvent())
+
+        assertEquals("${event.name}:error", responseEvent.name)
+        assertEquals("UNHANDLED_ERROR", responseEvent.payload.asJsonObject["code"].asString)
+    }
+
+    @Test
+    fun testCanHandleException() {
+        val event = buildRawRequestEvent()
+
+        eventHandlerRegistry.add(event.name!!, event.version!!) {
+            throw RuntimeException("error")
+        }
+
+        exceptionHandlerRegistry.register(RuntimeException::class.java) { _, requestEvent, _ ->
+            buildResponseEvent().copy("${requestEvent.name}:bad_request")
+        }
+
+        val responseEvent = rawEventProcessor.processEvent(event)
+
+        assertEquals("${event.name}:bad_request", responseEvent.name)
+    }
+
+    @Test
+    fun testBadProtocolEventIsReturned() {
+        val responseEvent = rawEventProcessor.processEvent(null)
+
+        assertEquals("badProtocol", responseEvent.name)
+        assertEquals("INVALID_COMMUNICATION_PROTOCOL", responseEvent.payload.asJsonObject["code"].asString)
+    }
+
+    @Test
+    fun testBadProtocolEventIsReturnedWhenParameterIsMissing() {
+        val event = buildRawRequestEvent().copy(version = null)
+
+        val responseEvent = rawEventProcessor.processEvent(event)
+
+        assertEquals("badProtocol", responseEvent.name)
+        assertEquals("INVALID_COMMUNICATION_PROTOCOL", responseEvent.payload.asJsonObject["code"].asString)
+        assertEquals("version", responseEvent.payload.asJsonObject["parameters"].asJsonObject["missingProperty"].asString)
+    }
+
+}


### PR DESCRIPTION
- Parte da lógica do EventProcessor foi movida para o RawEventProcessor que não faz a serialização e desserialização do evento.
- EventProcessor  foi adaptado para manter o mesmo comportamento utilizando o RawEventProcessor
- AWSLambdaEventProcessor criado para facilitar o uso da lib nos lambdas  da aws