### PR TITLE
Correções no AWSEventProcessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ repositories {
 A biblioteca é composta de 3 modulos. Server, Client e Core.
 
 ```
- compile "br.com.guiabolso:events-client:2.5.1"
- compile "br.com.guiabolso:events-server:2.5.1"
- compile "br.com.guiabolso:events-core:2.5.1"
+ compile "br.com.guiabolso:events-client:2.5.2"
+ compile "br.com.guiabolso:events-server:2.5.2"
+ compile "br.com.guiabolso:events-core:2.5.2"
 ```
 Geralmente as dependências a serem importadas são:
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
 
 allprojects {
     ext {
-        publish_version = '2.5.1'
+        publish_version = '2.5.2'
     }
 }
 

--- a/server/src/main/kotlin/br/com/guiabolso/events/server/AWSLambdaEventProcessor.kt
+++ b/server/src/main/kotlin/br/com/guiabolso/events/server/AWSLambdaEventProcessor.kt
@@ -1,16 +1,12 @@
 package br.com.guiabolso.events.server
 
-import br.com.guiabolso.events.builder.EventBuilder.Companion.badProtocol
-import br.com.guiabolso.events.json.MapperHolder
-import br.com.guiabolso.events.model.RawEvent
-import br.com.guiabolso.events.model.ResponseEvent
 import br.com.guiabolso.events.server.exception.ExceptionHandlerRegistry
 import br.com.guiabolso.events.server.handler.EventHandlerDiscovery
-import br.com.guiabolso.events.server.parser.EventParsingException
 import br.com.guiabolso.events.validation.EventValidator
 import br.com.guiabolso.events.validation.StrictEventValidator
 import br.com.guiabolso.tracing.Tracer
 import br.com.guiabolso.tracing.factory.TracerFactory
+import org.slf4j.LoggerFactory
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -19,33 +15,18 @@ class AWSLambdaEventProcessor
 constructor(
     discovery: EventHandlerDiscovery,
     exceptionHandlerRegistry: ExceptionHandlerRegistry,
-    private val tracer: Tracer = TracerFactory.createTracer(),
+    tracer: Tracer = TracerFactory.createTracer(),
     eventValidator: EventValidator = StrictEventValidator()
 ) {
 
-    private val eventProcessor = RawEventProcessor(discovery, exceptionHandlerRegistry, tracer, eventValidator)
+    private val eventProcessor = EventProcessor(discovery, exceptionHandlerRegistry, tracer, eventValidator)
 
     fun processEvent(input: InputStream, output: OutputStream) {
         val payload = readInput(input)
-
-        val response = try {
-            val rawEvent = parseEvent(payload)
-            eventProcessor.processEvent(rawEvent)
-        } catch (e: EventParsingException) {
-            tracer.notifyError(e, false)
-            badProtocol(e.eventMessage)
-        }
-
-        writeOutput(output, response.json())
-    }
-
-    private fun parseEvent(payload: String?): RawEvent? {
-        try {
-            val lambdaBody = MapperHolder.mapper.fromJson(payload, LambdaRequest::class.java)?.body ?: return null
-            return MapperHolder.mapper.fromJson(lambdaBody, RawEvent::class.java)
-        } catch (e: Throwable) {
-            throw EventParsingException(e)
-        }
+        logger.debug("Input: $payload")
+        val response = eventProcessor.processEvent(payload)
+        logger.debug("Output: $payload")
+        writeOutput(output, response)
     }
 
     private fun readInput(input: InputStream): String {
@@ -56,22 +37,8 @@ constructor(
         output.use { it.write(response.toByteArray()) }
     }
 
-    private fun ResponseEvent.json() = MapperHolder.mapper.toJson(
-        LambdaResponse(
-            statusCode = 200,
-            headers = mapOf("Content-Type" to "application/json"),
-            body = MapperHolder.mapper.toJson(this)
-        )
-    )
-
-    private data class LambdaRequest(
-        val body: String?
-    )
-
-    private data class LambdaResponse(
-        val statusCode: Int,
-        val headers: Map<String, String>,
-        val body: String
-    )
+    companion object {
+        private val logger = LoggerFactory.getLogger(AWSLambdaEventProcessor::class.java)
+    }
 
 }

--- a/server/src/main/kotlin/br/com/guiabolso/events/server/SAMLambdaEventProcessor.kt
+++ b/server/src/main/kotlin/br/com/guiabolso/events/server/SAMLambdaEventProcessor.kt
@@ -1,0 +1,86 @@
+package br.com.guiabolso.events.server
+
+import br.com.guiabolso.events.builder.EventBuilder.Companion.badProtocol
+import br.com.guiabolso.events.json.MapperHolder
+import br.com.guiabolso.events.model.RawEvent
+import br.com.guiabolso.events.model.ResponseEvent
+import br.com.guiabolso.events.server.exception.ExceptionHandlerRegistry
+import br.com.guiabolso.events.server.handler.EventHandlerDiscovery
+import br.com.guiabolso.events.server.parser.EventParsingException
+import br.com.guiabolso.events.validation.EventValidator
+import br.com.guiabolso.events.validation.StrictEventValidator
+import br.com.guiabolso.tracing.Tracer
+import br.com.guiabolso.tracing.factory.TracerFactory
+import org.slf4j.LoggerFactory
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ *  Used for running with AWS SAM because its input and expected output is different than the real AWS Lambda
+ */
+class SAMLambdaEventProcessor
+@JvmOverloads
+constructor(
+    discovery: EventHandlerDiscovery,
+    exceptionHandlerRegistry: ExceptionHandlerRegistry,
+    private val tracer: Tracer = TracerFactory.createTracer(),
+    eventValidator: EventValidator = StrictEventValidator()
+) {
+
+    private val eventProcessor = RawEventProcessor(discovery, exceptionHandlerRegistry, tracer, eventValidator)
+
+    fun processEvent(input: InputStream, output: OutputStream) {
+        val payload = readInput(input)
+        logger.debug("Input: $payload")
+
+        val response = try {
+            val rawEvent = parseEvent(payload)
+            eventProcessor.processEvent(rawEvent)
+        } catch (e: EventParsingException) {
+            tracer.notifyError(e, false)
+            badProtocol(e.eventMessage)
+        }.json()
+        logger.debug("Output: $response")
+        writeOutput(output, response)
+    }
+
+    private fun parseEvent(payload: String?): RawEvent? {
+        try {
+            val lambdaBody = MapperHolder.mapper.fromJson(payload, SAMLambdaRequest::class.java)?.body ?: return null
+            return MapperHolder.mapper.fromJson(lambdaBody, RawEvent::class.java)
+        } catch (e: Throwable) {
+            throw EventParsingException(e)
+        }
+    }
+
+    private fun readInput(input: InputStream): String {
+        return input.bufferedReader(Charsets.UTF_8).use { it.readText() }
+    }
+
+    private fun writeOutput(output: OutputStream, response: String) {
+        output.use { it.write(response.toByteArray()) }
+    }
+
+    private fun ResponseEvent.json() = MapperHolder.mapper.toJson(
+        SAMLambdaResponse(
+            statusCode = 200,
+            headers = mapOf("Content-Type" to "application/json"),
+            body = MapperHolder.mapper.toJson(this)
+        )
+    )
+
+    private data class SAMLambdaRequest(
+        val body: String?
+    )
+
+    private data class SAMLambdaResponse(
+        val statusCode: Int,
+        val headers: Map<String, String>,
+        val body: String
+    )
+
+    companion object {
+        private val logger = LoggerFactory.getLogger(SAMLambdaEventProcessor::class.java)
+    }
+
+}


### PR DESCRIPTION
Por comportamentos diferentes entre o AWS Lambda e o AWS SAM CLI precisamos de 2 implementações de processamento para o lamba enquanto isso não é corrigido