### PR TITLE
Added List type support for addProperty in TracerEngines.

### DIFF
--- a/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/TracerEngine.kt
+++ b/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/TracerEngine.kt
@@ -40,6 +40,15 @@ interface TracerEngine<C> {
     fun addProperty(key: String, value: Boolean?)
 
     /**
+     * Add a key/value pair to the current traced operation. These should be reported in errors and tracings.
+     *
+     * @param key Custom parameter key.
+     * @param value Custom parameter value.
+     * @since 2.0.0
+     */
+    fun addProperty(key: String, value: List<*>)
+
+    /**
      * Register an execution time using the current Engine, under the received metric name. The metric will be
      * registered with any tags that come within the context Map
      *

--- a/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/datadog/DatadogTracer.kt
+++ b/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/datadog/DatadogTracer.kt
@@ -29,6 +29,11 @@ open class DatadogTracer : TracerEngine<SpanBuilder> {
         if (value != null) tracer.activeSpan()?.setTag(key, value)
     }
 
+    override fun addProperty(key: String, value: List<*>) {
+        val finalValue:String = value.joinToString(",")
+        addProperty(key, finalValue)
+    }
+
     override fun recordExecutionTime(name: String, elapsedTime: Long, context: MutableMap<String, String>) {
         throw NotImplementedError("Import com.datadoghq:java-dogstatsd-client dependency to use this feature.")
     }

--- a/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/newrelic/NewRelicTracer.kt
+++ b/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/newrelic/NewRelicTracer.kt
@@ -26,6 +26,11 @@ class NewRelicTracer : TracerEngine<Token> {
         addCustomParameter(key, value.toString())
     }
 
+    override fun addProperty(key: String, value: List<*>) {
+        val finalValue:String = value.joinToString(",")
+        addProperty(key, finalValue)
+    }
+
     override fun recordExecutionTime(name: String, elapsedTime: Long, context: MutableMap<String, String>) {
         recordResponseTimeMetric(name, elapsedTime)
         context.forEach { addProperty(it.key, it.value) }

--- a/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/slf4j/Slf4JTracer.kt
+++ b/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/slf4j/Slf4JTracer.kt
@@ -23,6 +23,13 @@ class Slf4JTracer : TracerEngine<Map<String, String?>> {
         MDC.put(key, value?.toString())
     }
 
+    override fun addProperty(key: String, value: List<*>){
+        val finalValue:String = value.joinToString(",", "[", "]"){
+            "\"${it.toString()}\""
+        }
+        addProperty(key, finalValue)
+    }
+
     override fun recordExecutionTime(name: String, elapsedTime: Long, context: MutableMap<String, String>) {
         LOGGER.info("[$name] elapsedTime= $elapsedTime")
         context.forEach { addProperty(it.key, it.value) }

--- a/tracing/src/main/kotlin/br/com/guiabolso/tracing/factory/CompositeTracerEngine.kt
+++ b/tracing/src/main/kotlin/br/com/guiabolso/tracing/factory/CompositeTracerEngine.kt
@@ -23,6 +23,11 @@ class CompositeTracerEngine(
         tracers.forEach { it.addProperty(key, value) }
     }
 
+    override fun addProperty(key: String, value: List<*>) {
+        val finalValue:String = value.joinToString(",")
+        addProperty(key, finalValue)
+    }
+
     override fun <T> executeAndRecordTime(name: String, block: (MutableMap<String, String>) -> T): T {
         val start = System.currentTimeMillis()
         val context = mutableMapOf<String, String>()

--- a/tracing/src/main/kotlin/br/com/guiabolso/tracing/factory/CompositeTracerEngine.kt
+++ b/tracing/src/main/kotlin/br/com/guiabolso/tracing/factory/CompositeTracerEngine.kt
@@ -24,8 +24,7 @@ class CompositeTracerEngine(
     }
 
     override fun addProperty(key: String, value: List<*>) {
-        val finalValue:String = value.joinToString(",")
-        addProperty(key, finalValue)
+        tracers.forEach{ it.addProperty(key, value) }
     }
 
     override fun <T> executeAndRecordTime(name: String, block: (MutableMap<String, String>) -> T): T {

--- a/tracing/src/test/kotlin/br/com/guiabolso/tracing/factory/CompositeTracerEngineTest.kt
+++ b/tracing/src/test/kotlin/br/com/guiabolso/tracing/factory/CompositeTracerEngineTest.kt
@@ -3,7 +3,7 @@ package br.com.guiabolso.tracing.factory
 import br.com.guiabolso.tracing.engine.TracerEngine
 import com.nhaarman.mockito_kotlin.*
 import org.junit.jupiter.api.Test
-import org.mockito.ArgumentMatchers.anyString
+import org.mockito.ArgumentMatchers.anyList
 import java.io.Closeable
 
 class CompositeTracerEngineTest {
@@ -49,8 +49,8 @@ class CompositeTracerEngineTest {
         val item:List<Int> = listOf(1, 2, 3, 4, 5)
         engine.addProperty("key", item)
 
-        verify(mockEngine1, times(1)).addProperty(eq("key"), anyString())
-        verify(mockEngine2, times(1)).addProperty(eq("key"), anyString())
+        verify(mockEngine1, times(1)).addProperty(eq("key"), anyList<Int>())
+        verify(mockEngine2, times(1)).addProperty(eq("key"), anyList<Int>())
     }
 
     @Test

--- a/tracing/src/test/kotlin/br/com/guiabolso/tracing/factory/CompositeTracerEngineTest.kt
+++ b/tracing/src/test/kotlin/br/com/guiabolso/tracing/factory/CompositeTracerEngineTest.kt
@@ -1,11 +1,9 @@
 package br.com.guiabolso.tracing.factory
 
 import br.com.guiabolso.tracing.engine.TracerEngine
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.times
-import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.whenever
+import com.nhaarman.mockito_kotlin.*
 import org.junit.jupiter.api.Test
+import org.mockito.ArgumentMatchers.anyString
 import java.io.Closeable
 
 class CompositeTracerEngineTest {
@@ -44,6 +42,15 @@ class CompositeTracerEngineTest {
 
         verify(mockEngine1, times(1)).addProperty("key", true)
         verify(mockEngine2, times(1)).addProperty("key", true)
+    }
+
+    @Test
+    fun `should delegate addProperty as String for List`() {
+        val item:List<Int> = listOf(1, 2, 3, 4, 5)
+        engine.addProperty("key", item)
+
+        verify(mockEngine1, times(1)).addProperty(eq("key"), anyString())
+        verify(mockEngine2, times(1)).addProperty(eq("key"), anyString())
     }
 
     @Test


### PR DESCRIPTION
 Default behavior is to add List items as String separated by colons, except for Slf4j that produces a JSON like list of Strings