### PR TITLE
Add support to get userId as string.

### DIFF
--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/Event.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/Event.kt
@@ -34,6 +34,11 @@ sealed class Event {
             it.getAsJsonPrimitive("userId")?.asLong
         }
 
+    val userIdAsString: String?
+        get() = this.identity.withCheckedJsonNull("userId") {
+            it.getAsJsonPrimitive("userId")?.asString
+        }
+
     val origin: String?
         get() = this.metadata.withCheckedJsonNull("origin") {
             it.getAsJsonPrimitive("origin")?.asString

--- a/impl/java/core/src/test/kotlin/br/com/guiabolso/events/utils/EventsTest.kt
+++ b/impl/java/core/src/test/kotlin/br/com/guiabolso/events/utils/EventsTest.kt
@@ -49,6 +49,28 @@ class EventsTest {
     }
 
     @Test
+    fun testGetUserIdAsStringFromIdentityWhenItIsNull() {
+        val event = buildRequestEvent()
+        assertNull(event.userIdAsString)
+    }
+
+    @Test
+    fun testGetUserIdAsStringFromIdentityWhenItIsNumber() {
+        val event = buildRequestEvent().copy(
+            identity = JsonObject().apply { this.add("userId", JsonPrimitive(42)) }
+        )
+        assertEquals("42", event.userIdAsString)
+    }
+
+    @Test
+    fun testGetUserIdAsStringFromIdentityWhenItIsString() {
+        val event = buildRequestEvent().copy(
+            identity = JsonObject().apply { this.add("userId", JsonPrimitive("42")) }
+        )
+        assertEquals("42", event.userIdAsString)
+    }
+
+    @Test
     fun testGetUserIdFromIdentity() {
         assertNull(buildRequestEvent().userId)
 

--- a/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/RawEventProcessor.kt
+++ b/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/RawEventProcessor.kt
@@ -60,7 +60,7 @@ constructor(
         tracer.setOperationName("${event.name}:V${event.version}")
         tracer.addProperty("EventID", event.id)
         tracer.addProperty("FlowID", event.flowId)
-        tracer.addProperty("UserID", event.userId?.toString() ?: "unknown")
+        tracer.addProperty("UserID", event.userIdAsString ?: "unknown")
         tracer.addProperty("Origin", event.origin ?: "unknown")
     }
 


### PR DESCRIPTION
This change prevent the Event to throw a `NumberFormatException`. There is a use case on Guiabolso Connector when the partner does not have a internal `UserId` as Number, this way we are force the partner to create a new `UserId` only to consume event protocol.  