### PR TITLE
Add addAll functions to EventHandlerRegistry

### DIFF
--- a/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/EventHandlerRegistry.kt
+++ b/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/EventHandlerRegistry.kt
@@ -5,6 +5,10 @@ import br.com.guiabolso.events.model.ResponseEvent
 
 interface EventHandlerRegistry : EventHandlerDiscovery {
 
+    fun addAll(vararg handler: EventHandler) = addAll(handler.toList())
+    
+    fun addAll(handlers: Collection<EventHandler>) = handlers.forEach(::add)
+    
     fun add(handler: EventHandler)
 
     fun add(eventName: String, eventVersion: Int, handler: (RequestEvent) -> ResponseEvent)

--- a/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/SimpleEventHandlerRegistry.kt
+++ b/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/SimpleEventHandlerRegistry.kt
@@ -6,10 +6,6 @@ import org.slf4j.LoggerFactory
 
 class SimpleEventHandlerRegistry : EventHandlerRegistry {
 
-    companion object {
-        private val logger = LoggerFactory.getLogger(SimpleEventHandlerRegistry::class.java)
-    }
-
     private val handlers = mutableMapOf<Pair<String, Int>, EventHandler>()
 
     override fun add(handler: EventHandler) {
@@ -23,4 +19,7 @@ class SimpleEventHandlerRegistry : EventHandlerRegistry {
 
     override fun eventHandlerFor(eventName: String, eventVersion: Int) = handlers[eventName to eventVersion]
 
+    companion object {
+        private val logger = LoggerFactory.getLogger(SimpleEventHandlerRegistry::class.java)
+    }
 }

--- a/impl/java/server/src/test/kotlin/br/com/guiabolso/events/server/SimpleEventHandlerRegistryTest.kt
+++ b/impl/java/server/src/test/kotlin/br/com/guiabolso/events/server/SimpleEventHandlerRegistryTest.kt
@@ -1,6 +1,10 @@
 package br.com.guiabolso.events.server
 
 import br.com.guiabolso.events.EventBuilderForTest
+import br.com.guiabolso.events.builder.EventBuilder
+import br.com.guiabolso.events.model.RequestEvent
+import br.com.guiabolso.events.model.ResponseEvent
+import br.com.guiabolso.events.server.handler.EventHandler
 import br.com.guiabolso.events.server.handler.SimpleEventHandlerRegistry
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -8,6 +12,34 @@ import org.junit.jupiter.api.Test
 
 class SimpleEventHandlerRegistryTest {
 
+    @Test
+    fun `test can add multiple events (collection)`(){
+        val eventHandlerDiscovery = SimpleEventHandlerRegistry()
+        
+        val handlers = listOf(Handler1, Handler2)
+        
+        eventHandlerDiscovery.addAll(handlers)
+        
+        val handler1 = eventHandlerDiscovery.eventHandlerFor(Handler1.eventName, Handler1.eventVersion)
+        val handler2 = eventHandlerDiscovery.eventHandlerFor(Handler2.eventName, Handler2.eventVersion)
+        assertEquals(handler1, Handler1)
+        assertEquals(handler2, Handler2)
+    }
+
+    @Test
+    fun `test can add multiple events (vararg)`(){
+        val eventHandlerDiscovery = SimpleEventHandlerRegistry()
+
+        val handlers = listOf(Handler1, Handler2)
+
+        eventHandlerDiscovery.addAll(*handlers.toTypedArray())
+
+        val handler1 = eventHandlerDiscovery.eventHandlerFor(Handler1.eventName, Handler1.eventVersion)
+        val handler2 = eventHandlerDiscovery.eventHandlerFor(Handler2.eventName, Handler2.eventVersion)
+        assertEquals(handler1, Handler1)
+        assertEquals(handler2, Handler2)
+    }
+    
     @Test
     fun testCanHandleEvent() {
         val eventHandlerDiscovery = SimpleEventHandlerRegistry()
@@ -30,6 +62,29 @@ class SimpleEventHandlerRegistryTest {
         val handler = eventHandlerDiscovery.eventHandlerFor("event:name", 1)
 
         assertNull(handler)
+    }
+}
+
+private object Handler1 : EventHandler {
+    var handles = 0
+    
+    override val eventName = "Dummy1"
+    override val eventVersion = 1
+
+    override fun handle(event: RequestEvent): ResponseEvent {
+        handles++
+        return EventBuilder.responseFor(event) { }
+    }
+}
+private object Handler2 : EventHandler {
+    var handles = 0
+
+    override val eventName = "Dummy2"
+    override val eventVersion = 1
+
+    override fun handle(event: RequestEvent): ResponseEvent {
+        handles++
+        return EventBuilder.responseFor(event) {  }
     }
 }
 


### PR DESCRIPTION
This commit adds an utility method to EventHandlerRegistry.kt, enabling users to add multiple event handlers at once.

This reduces the boilerplate to register event, originally
```
handlers.forEach { simpleEventHandlerRegistry.add(it) }
```
to
```
SimpleEventHandlerRegistry.addAll(handlers)
```