### PR TITLE
Adding IsolatedTracer.kt and helpers to propagate span context through events

### DIFF
--- a/impl/java/build.gradle
+++ b/impl/java/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 
 allprojects {
     ext {
-        publish_version = '4.1.0'
+        publish_version = '4.2.0'
     }
     tasks.whenTaskAdded {
         if (name == "generateSourcesJarForMavenPublication") {

--- a/impl/java/client/src/main/kotlin/br/com/guiabolso/events/client/TracingEventClient.kt
+++ b/impl/java/client/src/main/kotlin/br/com/guiabolso/events/client/TracingEventClient.kt
@@ -1,0 +1,27 @@
+package br.com.guiabolso.events.client
+
+import br.com.guiabolso.events.client.model.Response
+import br.com.guiabolso.events.model.RequestEvent
+import br.com.guiabolso.events.tracer.propagation.EventFormat
+import br.com.guiabolso.events.tracer.propagation.EventTextMapAdapter
+import io.opentracing.Tracer
+
+class TracingEventClient(
+    private val inner: EventClient,
+    private val tracer: Tracer
+) {
+
+    @JvmOverloads
+    fun sendEvent(
+        url: String,
+        requestEvent: RequestEvent,
+        headers: Map<String, String> = emptyMap(),
+        timeout: Int? = null
+    ): Response {
+        val activeSpan = tracer.activeSpan()
+        if (activeSpan != null) {
+            tracer.inject(activeSpan.context(), EventFormat, EventTextMapAdapter(requestEvent))
+        }
+        return inner.sendEvent(url, requestEvent, headers, timeout)
+    }
+}

--- a/impl/java/core/build.gradle
+++ b/impl/java/core/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    api group: 'com.google.code.gson', name: 'gson', version: '2.8.5'
+    api group: 'com.google.code.gson', name: 'gson', version: '2.8.6'
     api project(":tracing")
 }
 

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/tracer/TracingEventUtils.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/tracer/TracingEventUtils.kt
@@ -1,0 +1,68 @@
+package br.com.guiabolso.events.tracer
+
+import br.com.guiabolso.events.model.RequestEvent
+import br.com.guiabolso.events.model.ResponseEvent
+import br.com.guiabolso.events.tracer.propagation.EventFormat
+import br.com.guiabolso.events.tracer.propagation.EventTextMapAdapter
+import br.com.guiabolso.tracing.utils.ExceptionUtils
+import datadog.trace.api.DDTags
+import io.opentracing.Span
+import io.opentracing.SpanContext
+import io.opentracing.Tracer
+import io.opentracing.tag.Tags
+
+fun Tracer.traceEvent(
+    operationName: String,
+    event: RequestEvent,
+    func: (Span) -> ResponseEvent,
+): ResponseEvent {
+    val span = newSpan(operationName, event)
+    return this.activateSpan(span).use {
+        try {
+            func(span)
+        } catch (e: Exception) {
+            notifyError(span, e)
+            throw e
+        } finally {
+            span.finish()
+        }
+    }
+}
+
+fun <R> Tracer.trace(operationName: String, func: (Span) -> R): R {
+    val span = newSpan(operationName)
+    return this.activateSpan(span).use {
+        try {
+            func(span)
+        } catch (e: Exception) {
+            notifyError(span, e)
+            throw e
+        } finally {
+            span.finish()
+        }
+    }
+}
+
+private fun Tracer.newSpan(operationName: String, requestEvent: RequestEvent? = null): Span {
+    val spanContext = getContext(requestEvent)
+
+    val spanBuilder = this.buildSpan(operationName)
+    if (spanContext != null) {
+        spanBuilder.asChildOf(spanContext)
+    } else {
+        spanBuilder.ignoreActiveSpan()
+    }
+    return spanBuilder.start()
+}
+
+private fun Tracer.getContext(requestEvent: RequestEvent?): SpanContext? = requestEvent?.run {
+    this@getContext.extract(EventFormat, EventTextMapAdapter(this))
+} ?: this@getContext.activeSpan()?.context()
+
+private fun notifyError(span: Span, e: Exception): Span? {
+    span.setTag(Tags.ERROR.key, true)
+    span.setTag(DDTags.ERROR_MSG, e.message ?: "Empty message")
+    span.setTag(DDTags.ERROR_TYPE, e.javaClass.name)
+    return span.setTag(DDTags.ERROR_STACK, ExceptionUtils.getStackTrace(e))
+}
+

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/tracer/TracingEventUtils.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/tracer/TracingEventUtils.kt
@@ -65,4 +65,3 @@ private fun notifyError(span: Span, e: Exception): Span? {
     span.setTag(DDTags.ERROR_TYPE, e.javaClass.name)
     return span.setTag(DDTags.ERROR_STACK, ExceptionUtils.getStackTrace(e))
 }
-

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/tracer/propagation/EventFormat.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/tracer/propagation/EventFormat.kt
@@ -1,0 +1,5 @@
+package br.com.guiabolso.events.tracer.propagation
+
+import io.opentracing.propagation.Format
+
+object EventFormat : Format<EventTextMapAdapter>

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/tracer/propagation/EventTextMapAdapter.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/tracer/propagation/EventTextMapAdapter.kt
@@ -1,0 +1,33 @@
+package br.com.guiabolso.events.tracer.propagation
+
+import br.com.guiabolso.events.json.MapperHolder.mapper
+import br.com.guiabolso.events.model.Event
+import com.google.gson.Gson
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import io.opentracing.propagation.TextMap
+import kotlin.collections.MutableMap.MutableEntry
+
+class EventTextMapAdapter(private val event: Event) : TextMap {
+
+    override fun iterator(): MutableIterator<MutableEntry<String, String>> {
+        val traceElement: JsonElement? = event.metadata["trace"]
+        val traceMap: MutableMap<String, String> = mapper.fromJson(traceElement) ?: mutableMapOf()
+
+        return traceMap.iterator()
+    }
+
+    override fun put(key: String, value: String?) {
+        traceElement().addProperty(key, value)
+    }
+
+    private fun traceElement(): JsonObject {
+        val metadata = event.metadata
+        if (!metadata.has("trace")) {
+            metadata.add("trace", JsonObject())
+        }
+        return metadata["trace"].asJsonObject
+    }
+
+    private inline fun <reified T> Gson.fromJson(element: JsonElement?): T? = fromJson(element, T::class.java)
+}

--- a/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/isolated/IsolatedTracer.kt
+++ b/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/isolated/IsolatedTracer.kt
@@ -1,0 +1,27 @@
+package br.com.guiabolso.tracing.isolated
+
+import io.opentracing.Scope
+import io.opentracing.ScopeManager
+import io.opentracing.Span
+import io.opentracing.Tracer
+import io.opentracing.util.ThreadLocalScopeManager
+
+/**
+ * Tracer that isolates the spans in a separated scopeManager
+ */
+class IsolatedTracer(tracer: Tracer) : Tracer by tracer {
+
+    private val scopeManager = ThreadLocalScopeManager()
+
+    override fun scopeManager(): ScopeManager {
+        return scopeManager
+    }
+
+    override fun activateSpan(span: Span): Scope {
+        return scopeManager().activate(span)
+    }
+
+    override fun activeSpan(): Span? {
+        return scopeManager().activeSpan()
+    }
+}


### PR DESCRIPTION
* IsolatedTracer is a tracer that isolates created spans in a different context from the standard tracer.
* TracingEventClient add the ability to propagate span contexts through events
* EventTracing utils adds helpers to create spans from received event contexts.
