### PR TITLE
Adicionando suporte básico para coroutines no EventsProcessor

### DIFF
--- a/impl/java/build.gradle
+++ b/impl/java/build.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
 
     dependencies {
-        classpath("org.jlleitschuh.gradle:ktlint-gradle:9.4.0")
+        classpath("org.jlleitschuh.gradle:ktlint-gradle:9.4.1")
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.novoda:bintray-release:0.9.2'
     }
@@ -79,5 +79,9 @@ subprojects {
             jvmTarget = '1.6'
             allWarningsAsErrors = true
         }
+    }
+
+    ktlint {
+        version = "0.39.0"
     }
 }

--- a/impl/java/build.gradle
+++ b/impl/java/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 
 allprojects {
     ext {
-        publish_version = '4.2.0'
+        publish_version = '4.3.0'
     }
     tasks.whenTaskAdded {
         if (name == "generateSourcesJarForMavenPublication") {
@@ -80,5 +80,4 @@ subprojects {
             allWarningsAsErrors = true
         }
     }
-
 }

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/context/EventCoroutineContextForwarder.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/context/EventCoroutineContextForwarder.kt
@@ -1,0 +1,24 @@
+package br.com.guiabolso.events.context
+
+import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.runBlocking
+
+/**
+ *  Compatibility layer for injecting the EventContext in a CoroutineScope
+ */
+object EventCoroutineContextForwarder {
+
+    private val holder = ThreadLocal<EventContext>()
+
+    val current: EventContext
+        get() = holder.get() ?: EventContext()
+
+    fun <R> withCoroutineContext(
+        context: EventContext = EventThreadContextManager.current,
+        func: suspend () -> R
+    ): R {
+        return runBlocking(holder.asContextElement(context)) {
+            func()
+        }
+    }
+}

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/utils/EventUtils.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/utils/EventUtils.kt
@@ -1,14 +1,15 @@
 package br.com.guiabolso.events.utils
 
+import br.com.guiabolso.events.context.EventCoroutineContextForwarder
 import br.com.guiabolso.events.context.EventThreadContextManager
 
 object EventUtils {
 
     @JvmStatic
     val eventId: String?
-        get() = EventThreadContextManager.current.id
+        get() = EventThreadContextManager.current.id ?: EventCoroutineContextForwarder.current.id
 
     @JvmStatic
     val flowId: String?
-        get() = EventThreadContextManager.current.flowId
+        get() = EventThreadContextManager.current.flowId ?: EventCoroutineContextForwarder.current.flowId
 }

--- a/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/RawEventProcessor.kt
+++ b/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/RawEventProcessor.kt
@@ -3,7 +3,7 @@ package br.com.guiabolso.events.server
 import br.com.guiabolso.events.builder.EventBuilder.Companion.badProtocol
 import br.com.guiabolso.events.builder.EventBuilder.Companion.eventNotFound
 import br.com.guiabolso.events.context.EventContext
-import br.com.guiabolso.events.context.EventThreadContextManager
+import br.com.guiabolso.events.context.EventThreadContextManager.withContext
 import br.com.guiabolso.events.model.Event
 import br.com.guiabolso.events.model.RawEvent
 import br.com.guiabolso.events.model.RequestEvent
@@ -33,7 +33,7 @@ constructor(
                     eventNotFound(event)
                 } else {
                     try {
-                        EventThreadContextManager.withContext(EventContext(event.id, event.flowId)).use {
+                        withContext(EventContext(event.id, event.flowId)).use {
                             startProcessingEvent(event)
                             handler.handle(event)
                         }

--- a/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/ConvertingEventHandler.kt
+++ b/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/ConvertingEventHandler.kt
@@ -1,0 +1,12 @@
+package br.com.guiabolso.events.server.handler
+
+import br.com.guiabolso.events.model.RequestEvent
+import br.com.guiabolso.events.model.ResponseEvent
+
+interface ConvertingEventHandler<T> : EventHandler {
+    fun convert(input: RequestEvent): T
+
+    fun handle(input: RequestEvent, converted: T): ResponseEvent
+
+    override fun handle(event: RequestEvent): ResponseEvent = handle(event, convert(event))
+}

--- a/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/EventHandler.kt
+++ b/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/EventHandler.kt
@@ -11,4 +11,3 @@ interface EventHandler {
 
     fun handle(event: RequestEvent): ResponseEvent
 }
-

--- a/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/EventHandler.kt
+++ b/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/EventHandler.kt
@@ -12,10 +12,3 @@ interface EventHandler {
     fun handle(event: RequestEvent): ResponseEvent
 }
 
-interface ConvertingEventHandler<T> : EventHandler {
-    fun convert(input: RequestEvent): T
-
-    fun handle(input: RequestEvent, converted: T): ResponseEvent
-
-    override fun handle(event: RequestEvent): ResponseEvent = handle(event, convert(event))
-}

--- a/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/SuspendingConvertingEventHandler.kt
+++ b/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/SuspendingConvertingEventHandler.kt
@@ -1,0 +1,14 @@
+package br.com.guiabolso.events.server.handler
+
+import br.com.guiabolso.events.model.RequestEvent
+import br.com.guiabolso.events.model.ResponseEvent
+
+interface SuspendingConvertingEventHandler<T> : SuspendingEventHandler {
+    suspend fun convert(input: RequestEvent): T
+
+    suspend fun handle(input: RequestEvent, converted: T): ResponseEvent
+
+    override suspend fun coHandle(event: RequestEvent): ResponseEvent {
+        return handle(event, convert(event))
+    }
+}

--- a/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/SuspendingEventHandler.kt
+++ b/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/SuspendingEventHandler.kt
@@ -14,4 +14,3 @@ interface SuspendingEventHandler : EventHandler {
             coHandle(event)
         }
 }
-

--- a/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/SuspendingEventHandler.kt
+++ b/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/handler/SuspendingEventHandler.kt
@@ -1,0 +1,17 @@
+package br.com.guiabolso.events.server.handler
+
+import br.com.guiabolso.events.context.EventContext
+import br.com.guiabolso.events.context.EventCoroutineContextForwarder.withCoroutineContext
+import br.com.guiabolso.events.model.RequestEvent
+import br.com.guiabolso.events.model.ResponseEvent
+
+interface SuspendingEventHandler : EventHandler {
+
+    suspend fun coHandle(event: RequestEvent): ResponseEvent
+
+    override fun handle(event: RequestEvent): ResponseEvent =
+        withCoroutineContext(EventContext(event.id, event.flowId)) {
+            coHandle(event)
+        }
+}
+

--- a/impl/java/server/src/test/kotlin/br/com/guiabolso/events/server/EventProcessorTest.kt
+++ b/impl/java/server/src/test/kotlin/br/com/guiabolso/events/server/EventProcessorTest.kt
@@ -2,11 +2,19 @@ package br.com.guiabolso.events.server
 
 import br.com.guiabolso.events.EventBuilderForTest.buildRequestEvent
 import br.com.guiabolso.events.EventBuilderForTest.buildResponseEvent
+import br.com.guiabolso.events.builder.EventBuilder.Companion.responseFor
 import br.com.guiabolso.events.json.MapperHolder
 import br.com.guiabolso.events.model.RawEvent
 import br.com.guiabolso.events.model.RequestEvent
+import br.com.guiabolso.events.model.ResponseEvent
 import br.com.guiabolso.events.server.exception.ExceptionHandlerRegistry
 import br.com.guiabolso.events.server.handler.SimpleEventHandlerRegistry
+import br.com.guiabolso.events.server.handler.SuspendingEventHandler
+import br.com.guiabolso.events.utils.EventUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -36,6 +44,39 @@ class EventProcessorTest {
 
         assertEquals(
             "{\"name\":\"event:name:response\",\"version\":1,\"id\":\"id\",\"flowId\":\"flowId\",\"payload\":42,\"identity\":{},\"auth\":{},\"metadata\":{}}",
+            responseEvent
+        )
+    }
+
+    @Test
+    fun testCanProcessSuspendingEvent() {
+        val event = buildRequestEvent()
+
+        eventHandlerRegistry.add(object : SuspendingEventHandler {
+            override val eventName = event.name
+            override val eventVersion: Int = event.version
+
+            override suspend fun coHandle(event: RequestEvent): ResponseEvent = coroutineScope {
+                val deferred = async {
+                    withContext(Dispatchers.IO) {
+                        //changes the context
+                        mapOf(
+                            "coId" to EventUtils.eventId,
+                            "coFlowId" to EventUtils.flowId
+                        )
+                    }
+                }
+                val result = deferred.await()
+                responseFor(event) {
+                    payload = result
+                }
+            }
+        })
+
+        val responseEvent = rawEventProcessor.processEvent(buildRequestEventString())
+
+        assertEquals(
+            "{\"name\":\"event:name:response\",\"version\":1,\"id\":\"id\",\"flowId\":\"flowId\",\"payload\":{\"coId\":\"id\",\"coFlowId\":\"flowId\"},\"identity\":{},\"auth\":{},\"metadata\":{}}",
             responseEvent
         )
     }

--- a/impl/java/server/src/test/kotlin/br/com/guiabolso/events/server/EventProcessorTest.kt
+++ b/impl/java/server/src/test/kotlin/br/com/guiabolso/events/server/EventProcessorTest.kt
@@ -59,7 +59,7 @@ class EventProcessorTest {
             override suspend fun coHandle(event: RequestEvent): ResponseEvent = coroutineScope {
                 val deferred = async {
                     withContext(Dispatchers.IO) {
-                        //changes the context
+                        // changes the context
                         mapOf(
                             "coId" to EventUtils.eventId,
                             "coFlowId" to EventUtils.flowId


### PR DESCRIPTION
Basicamente foi criado a interface SuspendingEventHandler que expoem um "suspending function" chamado "coHandle" para lidar com eventos.

Essa implementação já se encarrega de repassar o contexto do evento(id e flowId) para as coroutines criadas dentro do método "coHandle". Isso é importante pois ao criar eventos usando o EventBuilder ele vai conseguir propagar esses ids e flowIds para outras aplicações.
