### PR TITLE
Adding /events as an accepted route path on ktor

### DIFF
--- a/impl/java/build.gradle
+++ b/impl/java/build.gradle
@@ -23,7 +23,7 @@ buildscript {
 
 allprojects {
     ext {
-        publish_version = '5.0.3'
+        publish_version = '5.0.4'
     }
     tasks.whenTaskAdded {
         if (name == "generateSourcesJarForMavenPublication") {

--- a/impl/java/ktor/src/main/kotlin/br/com/guiabolso/events/Events.kt
+++ b/impl/java/ktor/src/main/kotlin/br/com/guiabolso/events/Events.kt
@@ -88,7 +88,7 @@ class Events(configuration: TraceConfiguration) {
 
             pipeline.intercept(ApplicationCallPipeline.Call) {
                 val path = call.request.path()
-                if (path == "/events/") {
+                if (path == "/events/" || path == "/events") {
                     call.respondText(
                         text = events.processEvent(call.receive()),
                         contentType = ContentType.Application.Json

--- a/impl/java/ktor/src/test/kotlin/br/com/guiabolso/events/EventsTest.kt
+++ b/impl/java/ktor/src/test/kotlin/br/com/guiabolso/events/EventsTest.kt
@@ -15,6 +15,7 @@ import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
 import io.ktor.application.Application
 import io.ktor.http.HttpMethod.Companion.Post
@@ -24,6 +25,15 @@ import io.ktor.server.testing.withTestApplication
 import java.util.UUID.randomUUID
 
 class EventsTest : ShouldSpec({
+
+    should("Have the same response for /events and /events/") {
+        withTestApplication({ testModule() }) {
+            val response = handleRequest(Post, "/events/") { setBody(testEvent) }.response
+            val response2 = handleRequest(Post, "/events") { setBody(testEvent) }.response
+
+            response shouldBe response2
+        }
+    }
 
     should("Handle a successful event request->response") {
         withTestApplication({ testModule() }) {


### PR DESCRIPTION
Most applications we use today use `/events` instead of `/events/`, but that path is not supported when using the ktor extension. This PR adds that support