### PR TITLE
Add default UTF-8 Ktor request encoding

### DIFF
--- a/impl/java/ktor/src/main/kotlin/br/com/guiabolso/events/Events.kt
+++ b/impl/java/ktor/src/main/kotlin/br/com/guiabolso/events/Events.kt
@@ -16,10 +16,12 @@ import io.ktor.application.call
 import io.ktor.application.featureOrNull
 import io.ktor.application.install
 import io.ktor.http.ContentType
+import io.ktor.request.contentCharset
 import io.ktor.request.path
-import io.ktor.request.receive
+import io.ktor.request.receiveChannel
 import io.ktor.response.respondText
 import io.ktor.util.AttributeKey
+import io.ktor.util.toByteArray
 import io.ktor.util.pipeline.ContextDsl
 import kotlin.reflect.KClass
 
@@ -89,8 +91,11 @@ class Events(configuration: TraceConfiguration) {
             pipeline.intercept(ApplicationCallPipeline.Call) {
                 val path = call.request.path()
                 if (path == "/events/" || path == "/events") {
+                    val rawEvent = call.receiveChannel()
+                        .toByteArray()
+                        .toString(call.request.contentCharset() ?: Charsets.UTF_8)
                     call.respondText(
-                        text = events.processEvent(call.receive()),
+                        text = events.processEvent(rawEvent),
                         contentType = ContentType.Application.Json
                     )
                     return@intercept finish()


### PR DESCRIPTION
By default, the Ktor charset is ISO_8859_1 and may cause issues with some characters from requests. It is possible to enforce the charset with the request headers, but it might require other systems to adapt doing so.

This PR sets the default charset for incoming requests as UTF-8.