### PR TITLE
Adding `@SerializedName` to solve bug when obfuscating android app

### DIFF
--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/Event.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/Event.kt
@@ -4,6 +4,7 @@ import br.com.guiabolso.events.json.MapperHolder
 import br.com.guiabolso.events.validation.withCheckedJsonNull
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 
 sealed class Event {
@@ -72,12 +73,27 @@ data class ResponseEvent(
 }
 
 data class RequestEvent(
+    @SerializedName("name")
     override val name: String,
+
+    @SerializedName("version")
     override val version: Int,
+
+    @SerializedName("id")
     override val id: String,
+
+    @SerializedName("flowId")
     override val flowId: String,
+
+    @SerializedName("payload")
     override val payload: JsonElement,
+
+    @SerializedName("identity")
     override val identity: JsonObject,
+
+    @SerializedName("auth")
     override val auth: JsonObject,
+
+    @SerializedName("metadata")
     override val metadata: JsonObject
 ) : Event()

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/EventMessage.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/EventMessage.kt
@@ -1,6 +1,10 @@
 package br.com.guiabolso.events.model
 
+import com.google.gson.annotations.SerializedName
+
 data class EventMessage(
+    @SerializedName("code")
     val code: String,
+    @SerializedName("parameters")
     val parameters: Map<String, Any?>
 )

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/RawEvent.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/RawEvent.kt
@@ -1,14 +1,23 @@
 package br.com.guiabolso.events.model
 
 import com.google.gson.JsonElement
+import com.google.gson.annotations.SerializedName
 
 data class RawEvent(
+    @SerializedName("name")
     val name: String?,
+    @SerializedName("version")
     val version: Int?,
+    @SerializedName("id")
     val id: String?,
+    @SerializedName("flowId")
     val flowId: String?,
+    @SerializedName("payload")
     val payload: JsonElement?,
+    @SerializedName("identity")
     val identity: JsonElement?,
+    @SerializedName("auth")
     val auth: JsonElement?,
+    @SerializedName("metadata")
     val metadata: JsonElement?
 )

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/RedirectPayload.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/RedirectPayload.kt
@@ -1,6 +1,10 @@
 package br.com.guiabolso.events.model
 
+import com.google.gson.annotations.SerializedName
+
 data class RedirectPayload(
+    @SerializedName("url")
     val url: String,
+    @SerializedName("queryParameters")
     val queryParameters: Map<String, Any> = emptyMap()
 )


### PR DESCRIPTION
Add `@SerializedName` into models because code obfuscation on android changes the names of fields when a release is created.