### PR TITLE
Mapping userId object

### DIFF
--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/Event.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/Event.kt
@@ -116,4 +116,4 @@ data class RequestEvent(
     override val metadata: JsonObject
 ) : Event()
 
-data class User(val id: Long, val type: String)
+data class User(val id: Long?, val type: String?)

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/Event.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/Event.kt
@@ -1,6 +1,9 @@
 package br.com.guiabolso.events.model
 
 import br.com.guiabolso.events.json.MapperHolder.mapper
+import br.com.guiabolso.events.validation.jsonObject
+import br.com.guiabolso.events.validation.long
+import br.com.guiabolso.events.validation.string
 import br.com.guiabolso.events.validation.withCheckedJsonNull
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
@@ -30,13 +33,13 @@ sealed class Event {
     inline fun <reified T> authAs(): T = this.auth.convertTo()
 
     val userId: Long?
-        get() = this.identity.withCheckedJsonNull("userId") {
-            it.getAsJsonPrimitive("userId")?.asLong
+        get() = with(this.identity) {
+            long("userId") ?: jsonObject("user")?.long("id")
         }
 
     val userIdAsString: String?
-        get() = this.identity.withCheckedJsonNull("userId") {
-            it.getAsJsonPrimitive("userId")?.asString
+        get() = with(this.identity) {
+            string("userId") ?: jsonObject("user")?.string("id")
         }
 
     val origin: String?

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/Event.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/model/Event.kt
@@ -7,6 +7,7 @@ import br.com.guiabolso.events.validation.string
 import br.com.guiabolso.events.validation.withCheckedJsonNull
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
+import com.google.gson.JsonSyntaxException
 import com.google.gson.annotations.SerializedName
 import com.google.gson.reflect.TypeToken
 
@@ -32,6 +33,11 @@ sealed class Event {
 
     inline fun <reified T> authAs(): T = this.auth.convertTo()
 
+    val user: User?
+        get() = with(this.identity) {
+            jsonObject("user")?.convertToOrNull(User::class.java)
+        }
+
     val userId: Long?
         get() = with(this.identity) {
             long("userId") ?: jsonObject("user")?.long("id")
@@ -50,6 +56,15 @@ sealed class Event {
     inline fun <reified T> JsonElement.convertTo(): T = mapper.fromJson(this, object : TypeToken<T>() {}.type)
 
     private fun <T> JsonElement.convertTo(clazz: Class<T>): T = mapper.fromJson(this, clazz)
+
+    @Suppress("SwallowedException")
+    private fun <T> JsonElement.convertToOrNull(clazz: Class<T>): T? {
+        return try {
+            this.convertTo(clazz)
+        } catch (e: JsonSyntaxException) {
+            null
+        }
+    }
 }
 
 data class ResponseEvent(
@@ -100,3 +115,5 @@ data class RequestEvent(
     @SerializedName("metadata")
     override val metadata: JsonObject
 ) : Event()
+
+data class User(val id: Long, val type: String)

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/validation/TypeValidationHelper.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/validation/TypeValidationHelper.kt
@@ -9,3 +9,28 @@ fun <T> JsonObject.withCheckedJsonNull(checkedParam: String, block: (jsonObject:
     } else {
         block(this)
     }
+
+fun JsonObject.string(key: String): String? {
+    val element = this.get(key)
+    return if (element != null && element !is JsonNull && element.isJsonPrimitive) {
+        element.asString
+    } else null
+}
+
+fun JsonObject.long(key: String): Long? {
+    val element = this.get(key)
+    return if (element != null && element !is JsonNull && element.isJsonPrimitive) {
+        try {
+            element.asLong
+        } catch (e: NumberFormatException) {
+            null
+        }
+    } else null
+}
+
+fun JsonObject.jsonObject(key: String): JsonObject? {
+    val element = this.get(key)
+    return if (element != null && element !is JsonNull && element.isJsonObject) {
+        element.asJsonObject
+    } else null
+}

--- a/impl/java/core/src/test/kotlin/br/com/guiabolso/events/utils/EventsTest.kt
+++ b/impl/java/core/src/test/kotlin/br/com/guiabolso/events/utils/EventsTest.kt
@@ -3,6 +3,7 @@ package br.com.guiabolso.events.utils
 import br.com.guiabolso.events.EventBuilderForTest.buildRequestEvent
 import br.com.guiabolso.events.EventBuilderForTest.buildResponseEvent
 import br.com.guiabolso.events.model.EventErrorType
+import br.com.guiabolso.events.model.User
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
@@ -116,6 +117,31 @@ class EventsTest {
             }
         )
         assertEquals(42L, responseEvent.userId)
+    }
+
+    @Test
+    fun testGetUserFromIdentity() {
+        val userId = 42L
+        val userType = "CONSUMER"
+
+        assertNull(buildRequestEvent().userId)
+
+        val responseEvent = buildRequestEvent().copy(
+            identity = JsonObject().apply {
+                this.add("user", JsonObject().apply {
+                    this.add("id", JsonPrimitive(userId))
+                    this.add("type", JsonPrimitive(userType))
+                })
+            }
+        )
+
+        assertEquals(User(id = userId, type = userType), responseEvent.user)
+    }
+
+    @Test
+    fun testGetUserFromIdentityWhenIsNull() {
+        val responseEvent = buildRequestEvent()
+        assertNull(responseEvent.user)
     }
 
     @Test

--- a/impl/java/core/src/test/kotlin/br/com/guiabolso/events/utils/EventsTest.kt
+++ b/impl/java/core/src/test/kotlin/br/com/guiabolso/events/utils/EventsTest.kt
@@ -63,9 +63,33 @@ class EventsTest {
     }
 
     @Test
+    fun testGetUserIdWithObjectAsStringFromIdentityWhenItIsNumber() {
+        val event = buildRequestEvent().copy(
+            identity = JsonObject().apply {
+                this.add("user", JsonObject().apply {
+                    this.add("id", JsonPrimitive(42))
+                })
+            }
+        )
+        assertEquals("42", event.userIdAsString)
+    }
+
+    @Test
     fun testGetUserIdAsStringFromIdentityWhenItIsString() {
         val event = buildRequestEvent().copy(
             identity = JsonObject().apply { this.add("userId", JsonPrimitive("42")) }
+        )
+        assertEquals("42", event.userIdAsString)
+    }
+
+    @Test
+    fun testGetUserIdWithObjectAsStringFromIdentityWhenItIsString() {
+        val event = buildRequestEvent().copy(
+            identity = JsonObject().apply {
+                this.add("user", JsonObject().apply {
+                    this.add("id", JsonPrimitive("42"))
+                })
+            }
         )
         assertEquals("42", event.userIdAsString)
     }
@@ -76,6 +100,20 @@ class EventsTest {
 
         val responseEvent = buildRequestEvent().copy(
             identity = JsonObject().apply { this.add("userId", JsonPrimitive(42)) }
+        )
+        assertEquals(42L, responseEvent.userId)
+    }
+
+    @Test
+    fun testGetUserIdWithObjectFromIdentity() {
+        assertNull(buildRequestEvent().userId)
+
+        val responseEvent = buildRequestEvent().copy(
+            identity = JsonObject().apply {
+                this.add("user", JsonObject().apply {
+                    this.add("id", JsonPrimitive(42))
+                })
+            }
         )
         assertEquals(42L, responseEvent.userId)
     }


### PR DESCRIPTION
Hoje o processor do protocolo de eventos espera que userId esteja na raiz do `identity`, agora também estamos enviando o id dentro de um objeto `user`. Por conta disso, não estamos enviando o id do usuário para o traces do APM.

`
identity: {
    user {
        id: 1L,
        type: "CONSUMER"
    }
}
`