### PR TITLE
Datadog Expected error

### DIFF
--- a/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/utils/DatadogUtils.kt
+++ b/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/utils/DatadogUtils.kt
@@ -66,7 +66,7 @@ object DatadogUtils {
 
     @JvmStatic
     fun notifyError(span: Span, exception: Throwable, expected: Boolean) {
-        span.setTag(Tags.ERROR.key, (!expected).toString())
+        span.setTag(Tags.ERROR.key, !expected)
         span.setTag(ERROR_MSG, exception.message ?: "Empty message")
         span.setTag(ERROR_TYPE, exception.javaClass.name)
         span.setTag(ERROR_STACK, ExceptionUtils.getStackTrace(exception))
@@ -74,7 +74,7 @@ object DatadogUtils {
 
     @JvmStatic
     fun notifyError(span: Span, message: String, params: Map<String, String?>, expected: Boolean) {
-        span.setTag(Tags.ERROR.key, (!expected).toString())
+        span.setTag(Tags.ERROR.key, !expected)
         span.setTag(ERROR_MSG, message)
         params.forEach { entry -> span.setTag(entry.key, entry.value) }
     }


### PR DESCRIPTION
Após a atualização do `dd-java-agent` da versão 0.80 para 0.92 no Dockerfile, as aplicações pararam de registrar as exceções definidas como esperadas `EventException (expected = true)` no datadog como sucesso, registrando-as como erros o que não é a intenção.

Para isso, foi necessário utilizar o método que recebe o valor booleano ao invés de uma String, conforme alteração no `DatadogUtils.notifyError()` ao chamar o `span.setTag('ERROR', expected)`.