### PR TITLE
Datadog EventException Expected

### DIFF
--- a/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/datadog/DatadogTracer.kt
+++ b/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/datadog/DatadogTracer.kt
@@ -80,7 +80,7 @@ open class DatadogTracer : TracerEngine, ThreadContextManager<Span> {
 
     override fun notifyRootError(exception: Throwable, expected: Boolean) {
         tracer.activeSpan()?.let { span ->
-            if (span is MutableSpan) span.localRootSpan.isError = true
+            if (span is MutableSpan) span.localRootSpan.isError = !expected
             DatadogUtils.notifyError(span, exception, expected)
         }
     }
@@ -94,7 +94,7 @@ open class DatadogTracer : TracerEngine, ThreadContextManager<Span> {
 
     override fun notifyRootError(message: String, params: Map<String, String?>, expected: Boolean) {
         tracer.activeSpan()?.let { span ->
-            if (span is MutableSpan) span.localRootSpan.isError = true
+            if (span is MutableSpan) span.localRootSpan.isError = !expected
             DatadogUtils.notifyError(span, message, params, expected)
         }
     }


### PR DESCRIPTION
Houve uma persistência no problema de spans no datadog gerados por `EventException` com `expected=true` sendo marcados como `ERROR` ao invés de `OK` mesmo com o ajuste na `6.0.2`.

O problema ocorre quando há uso da annotation `@Trace` e o uso de `withContext` (coroutines).

A alteração feita aqui corrige esse problema, apesar de ter sentido (exceções expected não devem ser consideradas como erro), não foi possível até então identificar a causa raiz que faz com que isso seja necessário quando usamos o `@Trace` e o uso de `withContext`.

Pelos breves testes que foram feitos, o problema acontece mesmo que a exceção seja lançada em um método sem as condições citadas acima, o que vale para chegar neste cenário é que o fluxo da lógica já tenha ou esteja passando em um método com `@Trace` e/ou `withContext`, ambos precisam ser utilizados, mas não precisam estar no mesmo método.