### PR TITLE
Allow user to customize null serialization behaviour

### DIFF
--- a/impl/java/json-moshi/src/main/kotlin/br/com/guiabolso/events/json/moshi/MoshiJsonAdapter.kt
+++ b/impl/java/json-moshi/src/main/kotlin/br/com/guiabolso/events/json/moshi/MoshiJsonAdapter.kt
@@ -15,9 +15,9 @@ import com.squareup.moshi.JsonAdapter as MoshiJsonAdapter
 class MoshiJsonAdapter(builder: Moshi.Builder.() -> Unit = { add(SerializeNullAdapterFactory) }) : JsonAdapter {
     private val moshi =
         Moshi.Builder()
+            .apply(builder)
             .add(JsonNodeFactory)
             .add(EventProtocolJsonAdapterFactory)
-            .apply(builder)
             .addLast(KotlinJsonAdapterFactory())
             .build()
 

--- a/impl/java/json-moshi/src/test/kotlin/br/com/guiabolso/events/json/moshi/adapter/MoshiJsonAdapterTest.kt
+++ b/impl/java/json-moshi/src/test/kotlin/br/com/guiabolso/events/json/moshi/adapter/MoshiJsonAdapterTest.kt
@@ -8,6 +8,7 @@ import br.com.guiabolso.events.json.TreeNode
 import br.com.guiabolso.events.json.fromJson
 import br.com.guiabolso.events.json.moshi.MoshiJsonAdapter
 import br.com.guiabolso.events.json.moshi.Sample
+import br.com.guiabolso.events.json.moshi.factory.SerializeNullAdapterFactory
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
@@ -42,10 +43,17 @@ class MoshiJsonAdapterTest : StringSpec({
         )
     )
 
-    val adapter = MoshiJsonAdapter()
+    val adapter = MoshiJsonAdapter {
+        add(SerializeNullAdapterFactory)
+    }
 
     "should serialize object successfully" {
         adapter.toJson(sample) shouldBe jsonString
+    }
+
+    "should serialize JsonNode successfully" {
+        adapter.toJson(jsonNode) shouldBe """{"int":42,"any":null,"boolean":false,"string":"string",""" +
+                """"map":{"bla":"bla"},"list":[42.42,{"nested":[]},true,"string"]}"""
     }
 
     "should successfully serialize nulls" {
@@ -64,7 +72,7 @@ class MoshiJsonAdapterTest : StringSpec({
         adapter.fromJson(jsonString, Sample::class.java) shouldBe sample
     }
 
-    "should deserialize successfully using JsonNodeAndTypeArgument" {
+    "should deserialize successfully using JsonNode and Type argument" {
         adapter.fromJson<Sample>(jsonNode) shouldBe sample
     }
 
@@ -80,7 +88,7 @@ class MoshiJsonAdapterTest : StringSpec({
         adapter.toJsonTree(jsonNode) shouldBeSameInstanceAs jsonNode
     }
 
-    "should create a JsonNodeTree" {
+    "should create a JsonNode tree" {
         val toJsonTree = adapter.toJsonTree(sample)
         toJsonTree shouldBe jsonNode
     }


### PR DESCRIPTION
The builder block initialize aren't allowing the user to configure a adapter delegator on TOP of the chain, this prevent the user to configure null serialization by default using `SerializeNullAdapterFactory`.
Calling the block initialize first before the JsonNode adapters register, allow JsonNull serialization to be catched by `SerializeNulls` adapter produced by `SerializeNullAdapterFactory` before reach the JsonNodeFactory.