### PR TITLE
deixa de forçar int para float

### DIFF
--- a/impl/java/server/src/test/kotlin/br/com/guiabolso/events/server/exception/handler/EventNotFoundExceptionHandlerTest.kt
+++ b/impl/java/server/src/test/kotlin/br/com/guiabolso/events/server/exception/handler/EventNotFoundExceptionHandlerTest.kt
@@ -35,7 +35,9 @@ class EventNotFoundExceptionHandlerTest {
 
         val message = responseEvent.payloadAs<EventMessage>()
         assertEquals("NO_EVENT_HANDLER_FOUND", message.code)
-        assertEquals(mapOf("event" to "eventName", "version" to 1.0), message.parameters)
+        assertEquals(setOf("event", "version"), message.parameters.keys)
+        assertEquals("eventName", message.parameters["event"])
+        assertEquals(1, message.parameters["version"].toString().toInt())
 
         verify { tracer.notifyError(exception, false) }
     }


### PR DESCRIPTION
Algumas bibliotecas divergem na abordagem de interpretação de números. Moshi e Gson por exemplo interpretam números como float na falta de algum type hint. Já o jackson faz o maior esforço pra manter os o tipo "certo" de números inteiros. Esse comportamento geralmente não é configurável. Não vi o Moshi, mas Gson e Jackson não permitem configuração.

Dado isso, o events-protocol não tem capacidade de forçar a unificação desse comportamento. Esse PR corrige um teste onde isso acontecia.