### PR TITLE
Downgrade slf4j 2.0.7 to version 1.7.36

### DIFF
--- a/impl/java/build.gradle.kts
+++ b/impl/java/build.gradle.kts
@@ -28,7 +28,7 @@ allprojects {
         implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 
         // SLF4J
-        implementation("org.slf4j:slf4j-api:2.0.7")
+        implementation("org.slf4j:slf4j-api:1.7.36")
 
         // Logback
         testImplementation("ch.qos.logback:logback-classic:1.4.6")


### PR DESCRIPTION
This will make possible clients have environment running on both version since slf4j is backward compatible