### PR TITLE
[tracing] - Usando api de Span

### DIFF
--- a/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/opentelemetry/OpenTelemetryTracer.kt
+++ b/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/opentelemetry/OpenTelemetryTracer.kt
@@ -28,7 +28,7 @@ class OpenTelemetryTracer : TracerEngine, ThreadContextManager<Span> {
     }
 
     override fun setOperationName(name: String) {
-        val span = getRootSpan()
+        val span = currentSpan()
         span?.updateName(name)
     }
 
@@ -37,7 +37,7 @@ class OpenTelemetryTracer : TracerEngine, ThreadContextManager<Span> {
     }
 
     override fun addRootProperty(key: String, value: String?) {
-        getRootSpan()?.addProperty(key, value)
+        currentSpan()?.addProperty(key, value)
     }
 
     override fun addProperty(key: String, value: Number?) {
@@ -45,7 +45,7 @@ class OpenTelemetryTracer : TracerEngine, ThreadContextManager<Span> {
     }
 
     override fun addRootProperty(key: String, value: Number?) {
-        getRootSpan()?.addProperty(key, value)
+        currentSpan()?.addProperty(key, value)
     }
 
     override fun addProperty(key: String, value: Boolean?) {
@@ -53,7 +53,7 @@ class OpenTelemetryTracer : TracerEngine, ThreadContextManager<Span> {
     }
 
     override fun addRootProperty(key: String, value: Boolean?) {
-        getRootSpan()?.addProperty(key, value)
+        currentSpan()?.addProperty(key, value)
     }
 
     override fun addProperty(key: String, value: List<*>) {
@@ -90,7 +90,7 @@ class OpenTelemetryTracer : TracerEngine, ThreadContextManager<Span> {
     }
 
     override fun notifyRootError(exception: Throwable, expected: Boolean) {
-        getRootSpan()?.let { span ->
+        currentSpan()?.let { span ->
             OpenTelemetryUtils.notifyError(span, exception, expected)
         }
     }
@@ -102,7 +102,7 @@ class OpenTelemetryTracer : TracerEngine, ThreadContextManager<Span> {
     }
 
     override fun notifyRootError(message: String, params: Map<String, String?>, expected: Boolean) {
-        getRootSpan()?.let { span ->
+        currentSpan()?.let { span ->
             OpenTelemetryUtils.notifyError(span, message, params, expected)
         }
     }
@@ -146,7 +146,7 @@ class OpenTelemetryTracer : TracerEngine, ThreadContextManager<Span> {
         } as AttributeKey<T>
     }
 
-    private fun getRootSpan(): Span? = Context.root().get(SpanContextKey.KEY)
+    private fun currentSpan(): Span? = Span.current()
 
     companion object {
         const val TRACER_NAME = "events-tracing"

--- a/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/opentelemetry/SpanContextKey.kt
+++ b/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/opentelemetry/SpanContextKey.kt
@@ -1,8 +1,0 @@
-package br.com.guiabolso.tracing.engine.opentelemetry
-
-import io.opentelemetry.api.trace.Span
-import io.opentelemetry.context.ContextKey
-
-internal object SpanContextKey {
-    internal val KEY = ContextKey.named<Span>("opentelemetry-trace-span-key")
-}


### PR DESCRIPTION
No open telemetry `ContextKey` são armazenadas por referência, então nossa estratégia em criar uma `ContextKey` com o mesmo nome para pegar o Span definido pelo open telemetry sdk não funciona como esperado.

Usar `Context.root()` é desencorajado na documentação da api, resolvi fazer um teste com uma aplicação instrumentada usando o javaagent do open telemetry, a conclusão é que teríamos perda de informações no Span, conforme imagem abaixo, criamos um span vazio, praticamente sem informação.

![image](https://github.com/GuiaBolso/events-protocol/assets/5836945/5021e9e0-5f43-481b-9848-c27c30638a67)

Agora, compare com a imagem da `Span.current() que contem o Span injetado pelo agent do open telemetry:
![image](https://github.com/GuiaBolso/events-protocol/assets/5836945/d5d4a76c-92f5-4fa4-9566-24503fb60b7f)

Diante do exposto, estou inclinado a depreciar a api `*RootAlguma`.