### PR TITLE
Adicionando possilbilidade de customizar erro no TraceAsNewOperation

### DIFF
--- a/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/utils/DatadogUtils.kt
+++ b/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/utils/DatadogUtils.kt
@@ -18,9 +18,13 @@ object DatadogUtils {
     fun traceAsNewOperation(
         name: String,
         type: String = HTTP_SERVER,
+        onError: suspend (Span, Exception) -> Unit = { span, e ->
+            notifyError(span, e, false)
+            throw e
+        },
         func: () -> Unit
     ) = runBlocking {
-        coTraceAsNewOperation(name, type) { func() }
+        coTraceAsNewOperation(name, type, onError) { func() }
     }
 
     suspend fun coTraceAsNewOperation(


### PR DESCRIPTION
## Contexto
Muitos sistemas utilizam o `DatadogUtils.coTraceAsNewOperation (...)` pra criar o rootSpan `netty.request` e manter os traces nos mesmos `operations` e, utilizando o protocolo de eventos com o processador de eventos.

Os `EventException`s tem um atributo `expected`, que utilizamos pra tratar se esta exception será ou não tratada como erro no trace e, assim terá um comportamento diferente nos monitores de alerta.

O processador de eventos, utiliza o `ExceptionHandlerRegistry` para tratar as exceptions configuradas neste processador de eventos e, algumas vezes, precisamos apenas notificar o 'erro' para o Datadog, porém com a tag de `erro` para false e ao invés de retornar um payload no padrão protocolo de eventos, precisamos re-lançar a exception (nos casos de JmsListener para a mensagem cair em DLQ) 

## Problema
O problema de relançar uma exception dentro do coTraceAsNewOperation pelo processador de eventos, é que este método do DatadogUtils também valida a execução do método com try catch, porém, lança faz a captura apenas de `Exception` (não tem como capturar EventException) e, notifica como erro não esperado, mesmo a exception sendo esperada

Um exemplo, seria que a nível de *negócio* lançamos algo como erro (exception), porém é algo esperado devido a estarmos habilitando ou desabilitando alguma feature.

Em consentimento, muitas vezes temos que desabilitar um `provider`, ao qual um usuário não conseguirá completar seu fluxo de criação de consentimento e este, será rejeitado automaticamente após um período. Neste momento de rejeição, está sendo lançado uma exceção de provider desabilitado, ao qual é uma regra de negócio esperada, tanto que a exception está configurada para ser uma exception `expected`.

## Sugestão
Tenho como sugestão, adicionar a possibilidade de customizar o que será realizado no `catch`, mas sem quebrar quaisquer códigos que já utilizam este método, desta forma, o desenvolvedor poderá criar novos traces ou apenas relançar a exception

```kotlin
// Valores default
traceAsNewOperation("netty.request") {
   // code here
} 

// Apenas error custom
traceAsNewOperation("netty.request",  onError = { _, e -> throw e }) {
   // code here
} 

// All Custom
traceAsNewOperation("netty.request",  MESSAGE_CONSUMER, ::onError) {
   // code here
} 

fun onError(span: Span, e: Exception) { ... }

```