### PR TITLE
Tornando o span um elemento no contexto de coroutine 

### DIFF
--- a/impl/java/tracing/build.gradle.kts
+++ b/impl/java/tracing/build.gradle.kts
@@ -9,8 +9,9 @@ dependencies {
     api("io.opentracing:opentracing-util:0.33.0")
 
     // Open Telemetry
-    api("io.opentelemetry:opentelemetry-api:1.27.0")
-    
+    api("io.opentelemetry:opentelemetry-api:1.28.0")
+    api("io.opentelemetry:opentelemetry-extension-kotlin:1.28.0")
+
     // AspectJ
     implementation("org.aspectj:aspectjweaver:1.9.19")
 }

--- a/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/utils/opentelemetry/OpenTelemetryUtils.kt
+++ b/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/utils/opentelemetry/OpenTelemetryUtils.kt
@@ -7,7 +7,9 @@ import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.api.trace.StatusCode
 import io.opentelemetry.api.trace.Tracer
+import io.opentelemetry.extension.kotlin.asContextElement
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 
 object OpenTelemetryUtils {
 
@@ -36,7 +38,7 @@ object OpenTelemetryUtils {
             .setSpanKind(kind)
             .setNoParent()
             .startSpan()!!
-        span.makeCurrent().use {
+        withContext(span.asContextElement()) {
             try {
                 func()
             } catch (e: Exception) {
@@ -59,8 +61,7 @@ object OpenTelemetryUtils {
 
     suspend fun <T> suspendingTraceBlock(name: String, func: suspend () -> T): T {
         val span = tracer.spanBuilder(name).startSpan()!!
-        val scope = span.makeCurrent()!!
-        return scope.use {
+        return withContext(span.asContextElement()) {
             try {
                 func()
             } catch (e: Exception) {


### PR DESCRIPTION
Documentação de `makeCurrent()`
>The default implementation of this method will store the Context in a ThreadLocal. Kotlin coroutine users SHOULD NOT use this method as the ThreadLocal will not be properly synced across coroutine suspension and resumption. Instead, use withContext(context.asContextElement()) provided by the opentelemetry-extension-kotlin library.