### PR TITLE
use jvm type to discover value types using reflection

### DIFF
--- a/impl/java/tracing/src/test/kotlin/br/com/guiabolso/tracing/engine/opentelemetry/OpenTelemetryTracerTest.kt
+++ b/impl/java/tracing/src/test/kotlin/br/com/guiabolso/tracing/engine/opentelemetry/OpenTelemetryTracerTest.kt
@@ -1,0 +1,60 @@
+package br.com.guiabolso.tracing.engine.opentelemetry
+
+import io.mockk.spyk
+import io.mockk.verify
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.Span
+import org.junit.jupiter.api.Test
+
+private val otel = OpenTelemetry.noop().apply(GlobalOpenTelemetry::set)
+class OpenTelemetryTracerTest {
+    private val openTelemetryTracer = OpenTelemetryTracer()
+
+    @Test
+    fun `should add all supported properties successfully`() {
+        val span = currentSpyiedSpan()
+        openTelemetryTracer.run {
+            addProperty("boolean", true)
+            addProperty("string", "Hello World")
+            addProperty("byte", Byte.MAX_VALUE)
+            addProperty("short", Short.MAX_VALUE)
+            addProperty("int", Int.MAX_VALUE)
+            addProperty("float", Float.MAX_VALUE)
+            addProperty("long", Long.MAX_VALUE)
+            addProperty("double", Double.MAX_VALUE)
+            addProperty("list", listOf("a", 1, "b"))
+        }
+        verify {
+            span.setAttribute(AttributeKey.booleanKey("boolean"), true)
+            span.setAttribute(AttributeKey.stringKey("string"), "Hello World")
+            span.setAttribute(AttributeKey.longKey("byte"), Byte.MAX_VALUE.toLong())
+            span.setAttribute(AttributeKey.longKey("short"), Short.MAX_VALUE.toLong())
+            span.setAttribute(AttributeKey.longKey("int"), Int.MAX_VALUE.toLong())
+            span.setAttribute(AttributeKey.longKey("long"), Long.MAX_VALUE)
+            span.setAttribute(AttributeKey.doubleKey("float"), Float.MAX_VALUE.toDouble())
+            span.setAttribute(AttributeKey.doubleKey("double"), Double.MAX_VALUE)
+            span.setAttribute(AttributeKey.stringKey("list"), "a,1,b")
+        }
+    }
+
+    @Test
+    fun `should set operation name successfully`() {
+        val span = currentSpyiedSpan()
+        openTelemetryTracer.setOperationName("my-operation")
+
+        verify(exactly = 1) {
+            span.updateName("my-operation")
+        }
+    }
+
+    private fun currentSpyiedSpan(): Span {
+        return otel.getTracer(OpenTelemetryTracer.TRACER_NAME)
+            .spanBuilder("name")
+            .setNoParent()
+            .startSpan()
+            .run { spyk(this) }
+            .also { it.makeCurrent() }
+    }
+}


### PR DESCRIPTION
Kotlin docs:
> On the JVM platform, numbers are stored as primitive types: int, double, and so on. Exceptions are cases when you create a nullable number reference such as Int? or use generics. In these cases numbers are boxed in Java classes Integer, Double, and so on.
https://kotlinlang.org/docs/numbers.html#numbers-representation-on-the-jvm