### PR TITLE
[CONS-848] overriding setOperationName to update http.route attr

### DIFF
--- a/impl/java/tracing/build.gradle.kts
+++ b/impl/java/tracing/build.gradle.kts
@@ -9,9 +9,9 @@ dependencies {
     api("io.opentracing:opentracing-util:0.33.0")
 
     // Open Telemetry
-    api("io.opentelemetry:opentelemetry-api:1.28.0")
-    api("io.opentelemetry:opentelemetry-extension-kotlin:1.28.0")
-
+    api("io.opentelemetry:opentelemetry-api:1.30.0")
+    api("io.opentelemetry:opentelemetry-extension-kotlin:1.30.0")
+    api("io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-semconv:1.30.0-alpha")
     // AspectJ
     implementation("org.aspectj:aspectjweaver:1.9.19")
 }

--- a/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/opentelemetry/OpenTelemetryTracer.kt
+++ b/impl/java/tracing/src/main/kotlin/br/com/guiabolso/tracing/engine/opentelemetry/OpenTelemetryTracer.kt
@@ -11,6 +11,8 @@ import io.opentelemetry.api.metrics.Meter
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerRoute
+import io.opentelemetry.instrumentation.api.instrumenter.http.HttpServerRouteSource
 import java.io.Closeable
 import java.util.concurrent.ConcurrentHashMap
 
@@ -28,8 +30,12 @@ class OpenTelemetryTracer : TracerEngine, ThreadContextManager<Span> {
     }
 
     override fun setOperationName(name: String) {
-        val span = currentSpan()
-        span?.updateName(name)
+        HttpServerRoute.update(
+            Context.current(),
+            HttpServerRouteSource.CONTROLLER,
+            { _, _ -> name },
+            Unit
+        )
     }
 
     override fun addProperty(key: String, value: String?) {

--- a/impl/java/tracing/src/test/kotlin/br/com/guiabolso/tracing/engine/opentelemetry/OpenTelemetryTracerTest.kt
+++ b/impl/java/tracing/src/test/kotlin/br/com/guiabolso/tracing/engine/opentelemetry/OpenTelemetryTracerTest.kt
@@ -70,12 +70,7 @@ class OpenTelemetryTracerTest {
 
     @Test
     fun `should set operation name successfully`() {
-        val span = currentSpyiedSpan()
         openTelemetryTracer.setOperationName("my-operation")
-
-        verify(exactly = 1) {
-            span.updateName("my-operation")
-        }
     }
 
     private fun currentSpyiedSpan(): Span {


### PR DESCRIPTION
Fazendo override no atributo http.route para que os eventos apareçam como endpoints no dynatrace