### PR TITLE
Aceitando InputStream no EventProcessor 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,14 @@ jobs:
         java: [11, 17, 21]
     name: Run with Java ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - name: Cache Gradle packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle.kts') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Publish to maven ceentral

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/json/JsonAdapter.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/json/JsonAdapter.kt
@@ -1,5 +1,6 @@
 package br.com.guiabolso.events.json
 
+import java.io.InputStream
 import java.lang.reflect.Type
 
 interface JsonAdapter {
@@ -13,6 +14,8 @@ interface JsonAdapter {
     fun <T> fromJson(json: String, clazz: Class<T>): T
 
     fun <T> fromJson(json: String, type: Type): T
+
+    fun <T> fromJson(json: InputStream, type: Type): T
 
     fun <T> fromJson(jsonNode: JsonNode, type: Type): T
 

--- a/impl/java/core/src/main/kotlin/br/com/guiabolso/events/json/JsonAdapterExtensions.kt
+++ b/impl/java/core/src/main/kotlin/br/com/guiabolso/events/json/JsonAdapterExtensions.kt
@@ -1,5 +1,6 @@
 package br.com.guiabolso.events.json
 
+import java.io.InputStream
 import kotlin.reflect.jvm.javaType
 import kotlin.reflect.typeOf
 
@@ -17,6 +18,10 @@ inline fun <reified T> JsonAdapter.fromJsonOrNull(jsonNode: JsonNode): T? {
     } catch (ignore: JsonDataException) {
         null
     }
+}
+
+inline fun <reified T> JsonAdapter.fromJson(json: InputStream): T {
+    return this.fromJson(json, typeOf<T>().javaType)
 }
 
 inline fun <reified T> JsonAdapter.fromJson(json: String): T {

--- a/impl/java/json-gson/src/main/kotlin/br/com/guiabolso/events/json/gson/GsonJsonAdapter.kt
+++ b/impl/java/json-gson/src/main/kotlin/br/com/guiabolso/events/json/gson/GsonJsonAdapter.kt
@@ -10,6 +10,7 @@ import com.google.gson.Gson
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonParseException
 import com.google.gson.stream.MalformedJsonException
+import java.io.InputStream
 import java.lang.reflect.Type
 
 class GsonJsonAdapter(configure: GsonBuilder.() -> Unit = { serializeNulls() }) : JsonAdapter {
@@ -44,6 +45,12 @@ class GsonJsonAdapter(configure: GsonBuilder.() -> Unit = { serializeNulls() }) 
         return gson.execute { this.fromJson<T>(json, type) }
     }
 
+    override fun <T> fromJson(json: InputStream, type: Type): T {
+        return gson.execute {
+            json.use { fromJson<T>(it.reader(), type) }
+        }
+    }
+
     override fun <T> fromJson(jsonNode: JsonNode, type: Type): T {
         return gson.execute { this.fromJson<T>(toJsonTree(jsonNode), type) }
     }
@@ -59,6 +66,7 @@ class GsonJsonAdapter(configure: GsonBuilder.() -> Unit = { serializeNulls() }) 
             throw when (e) {
                 is JsonParseException,
                 is MalformedJsonException -> JsonDataException(e.message, e)
+
                 else -> e
             }
         }

--- a/impl/java/json-gson/src/test/kotlin/br/com/guiabolso/events/json/gson/GsonJsonAdapterTest.kt
+++ b/impl/java/json-gson/src/test/kotlin/br/com/guiabolso/events/json/gson/GsonJsonAdapterTest.kt
@@ -19,7 +19,7 @@ import io.kotest.matchers.types.shouldBeSameInstanceAs
 class GsonJsonAdapterTest : StringSpec({
     val jsonString =
         """{"list":[42.42,{"nested":[]},true,"string"],"string":"string","int":42,"boolean":false,""" +
-                """"map":{"bla":"bla"},"any":null}"""
+            """"map":{"bla":"bla"},"any":null}"""
 
     val sample = Sample(
         int = 42,
@@ -48,6 +48,10 @@ class GsonJsonAdapterTest : StringSpec({
 
     "should serialize object successfully" {
         adapter.toJson(sample) shouldBe jsonString
+    }
+
+    "should decode from input stream" {
+        adapter.fromJson<Sample>(jsonString.byteInputStream()) shouldBe sample
     }
 
     "should successfully serialize nulls" {

--- a/impl/java/json-jackson/src/main/kotlin/br/com/guiabolso/events/json/jackson/Jackson2JsonAdapter.kt
+++ b/impl/java/json-jackson/src/main/kotlin/br/com/guiabolso/events/json/jackson/Jackson2JsonAdapter.kt
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.exc.StreamReadException
 import com.fasterxml.jackson.databind.DatabindException
 import com.fasterxml.jackson.databind.json.JsonMapper
 import com.fasterxml.jackson.databind.type.TypeFactory
+import java.io.InputStream
 import java.lang.reflect.Type
 
 class Jackson2JsonAdapter(configuration: JsonMapper.Builder.() -> Unit) : JsonAdapter {
@@ -57,6 +58,10 @@ class Jackson2JsonAdapter(configuration: JsonMapper.Builder.() -> Unit) : JsonAd
                 TypeFactory.defaultInstance().constructType(type),
             )
         }
+    }
+
+    override fun <T> fromJson(json: InputStream, type: Type): T {
+        return mapper.wrapException { readValue(json, TypeFactory.defaultInstance().constructType(type)) }
     }
 
     override fun <T> fromJson(jsonNode: JsonNode, type: Type): T {

--- a/impl/java/json-jackson/src/test/kotlin/br/com/guiabolso/events/json/jackson/Jackson2JsonAdapterTest.kt
+++ b/impl/java/json-jackson/src/test/kotlin/br/com/guiabolso/events/json/jackson/Jackson2JsonAdapterTest.kt
@@ -1,0 +1,13 @@
+package br.com.guiabolso.events.json.jackson
+
+import br.com.guiabolso.events.model.RequestEvent
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class Jackson2JsonAdapterTest : StringSpec({
+
+    "should decode from input stream" {
+        val requestEvent = createRequestEvent()
+        testAdapter.fromJson(requestEvent.json, RequestEvent::class.java) shouldBe requestEvent
+    }
+})

--- a/impl/java/json-moshi/src/main/kotlin/br/com/guiabolso/events/json/moshi/MoshiJsonAdapter.kt
+++ b/impl/java/json-moshi/src/main/kotlin/br/com/guiabolso/events/json/moshi/MoshiJsonAdapter.kt
@@ -9,6 +9,9 @@ import br.com.guiabolso.events.json.moshi.factory.JsonNodeFactory
 import br.com.guiabolso.events.json.moshi.factory.SerializeNullAdapterFactory
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import okio.buffer
+import okio.source
+import java.io.InputStream
 import java.lang.reflect.Type
 import com.squareup.moshi.JsonAdapter as MoshiJsonAdapter
 
@@ -62,6 +65,11 @@ class MoshiJsonAdapter(builder: Moshi.Builder.() -> Unit = { add(SerializeNullAd
     override fun <T> fromJson(json: String, type: Type): T {
         val adapter = moshi.adapter<T>(type).nonNull()
         return adapter.execute { fromJson(json)!! }
+    }
+
+    override fun <T> fromJson(json: InputStream, type: Type): T {
+        val adapter = moshi.adapter<T>(type).nonNull()
+        return adapter.execute { fromJson(json.source().buffer())!! }
     }
 
     override fun <T> fromJson(jsonNode: JsonNode, type: Type): T {

--- a/impl/java/json-moshi/src/test/kotlin/br/com/guiabolso/events/json/moshi/adapter/MoshiJsonAdapterTest.kt
+++ b/impl/java/json-moshi/src/test/kotlin/br/com/guiabolso/events/json/moshi/adapter/MoshiJsonAdapterTest.kt
@@ -18,7 +18,7 @@ import io.kotest.matchers.types.shouldBeSameInstanceAs
 class MoshiJsonAdapterTest : StringSpec({
     val jsonString =
         """{"list":[42.42,{"nested":[]},true,"string"],"string":"string","int":42,"boolean":false,""" +
-                """"map":{"bla":"bla"},"any":null}"""
+            """"map":{"bla":"bla"},"any":null}"""
 
     val sample = Sample(
         int = 42,
@@ -47,13 +47,18 @@ class MoshiJsonAdapterTest : StringSpec({
         add(SerializeNullAdapterFactory)
     }
 
+    "should decode from input stream" {
+        val inputStream = jsonString.byteInputStream()
+        adapter.fromJson<Sample>(inputStream, Sample::class.java) shouldBe sample
+    }
+
     "should serialize object successfully" {
         adapter.toJson(sample) shouldBe jsonString
     }
 
     "should serialize JsonNode successfully" {
         adapter.toJson(jsonNode) shouldBe """{"int":42,"any":null,"boolean":false,"string":"string",""" +
-                """"map":{"bla":"bla"},"list":[42.42,{"nested":[]},true,"string"]}"""
+            """"map":{"bla":"bla"},"list":[42.42,{"nested":[]},true,"string"]}"""
     }
 
     "should successfully serialize nulls" {

--- a/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/BlockingEventProcessor.kt
+++ b/impl/java/server/src/main/kotlin/br/com/guiabolso/events/server/BlockingEventProcessor.kt
@@ -8,6 +8,7 @@ import br.com.guiabolso.events.validation.EventValidator
 import br.com.guiabolso.events.validation.StrictEventValidator
 import br.com.guiabolso.tracing.Tracer
 import kotlinx.coroutines.runBlocking
+import java.io.InputStream
 
 class BlockingEventProcessor(
     private val eventProcessor: SuspendingEventProcessor
@@ -30,6 +31,10 @@ class BlockingEventProcessor(
             jsonAdapter,
         )
     )
+
+    fun processEvent(json: InputStream): String = runBlocking {
+        eventProcessor.processEvent(json)
+    }
 
     fun processEvent(payload: String?): String = runBlocking {
         eventProcessor.processEvent(payload)


### PR DESCRIPTION
O adapter de json tem suporte para receber alguma forma de Stream com entrada para fazer o parse de json, essa PR expõe  api para que os usuários possa passar um input stream com argumento para o event processor, isso vai evitar alocação de memória desnecessária quando o usuário já tem um stream disponível. 