### PR TITLE
Trocando fuel por OkHttp

### DIFF
--- a/impl/java/client/build.gradle.kts
+++ b/impl/java/client/build.gradle.kts
@@ -7,5 +7,7 @@ dependencies {
     testImplementation(project(":json-jackson"))
 
     // Fuel
-    implementation("com.github.kittinunf.fuel:fuel:2.3.1")
+    compileOnly("com.github.kittinunf.fuel:fuel:2.3.1")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }

--- a/impl/java/client/src/main/kotlin/br/com/guiabolso/events/client/EventClient.kt
+++ b/impl/java/client/src/main/kotlin/br/com/guiabolso/events/client/EventClient.kt
@@ -3,7 +3,7 @@ package br.com.guiabolso.events.client
 import br.com.guiabolso.events.client.adapter.HttpClientAdapter
 import br.com.guiabolso.events.client.exception.BadProtocolException
 import br.com.guiabolso.events.client.exception.TimeoutException
-import br.com.guiabolso.events.client.http.FuelHttpClient
+import br.com.guiabolso.events.client.http.OkHttpClientAdapter
 import br.com.guiabolso.events.client.model.Response
 import br.com.guiabolso.events.client.model.toContext
 import br.com.guiabolso.events.json.JsonAdapter
@@ -19,7 +19,7 @@ class EventClient
 @JvmOverloads
 constructor(
     private val jsonAdapter: JsonAdapter,
-    private val httpClient: HttpClientAdapter = FuelHttpClient(),
+    private val httpClient: HttpClientAdapter = OkHttpClientAdapter(),
     private val eventValidator: EventValidator = StrictEventValidator(),
     private val defaultTimeout: Int = 60000
 ) {

--- a/impl/java/client/src/main/kotlin/br/com/guiabolso/events/client/http/FuelHttpClient.kt
+++ b/impl/java/client/src/main/kotlin/br/com/guiabolso/events/client/http/FuelHttpClient.kt
@@ -10,6 +10,13 @@ import com.github.kittinunf.result.getAs
 import java.net.SocketTimeoutException
 import java.nio.charset.Charset
 
+@Deprecated(
+    "Performance degradation when compared to other http clients in high load.",
+    replaceWith = ReplaceWith(
+        "OkHttpClientAdapter",
+        "br.com.guiabolso.events.client.http.OkHttpClientAdapter"
+    )
+)
 class FuelHttpClient : HttpClientAdapter {
 
     override fun post(
@@ -30,6 +37,7 @@ class FuelHttpClient : HttpClientAdapter {
             is Result.Success -> {
                 return result.getAs<String>()!!
             }
+
             is Result.Failure -> {
                 val error: FuelError? = result.getAs()
                 if (error?.exception is SocketTimeoutException) {

--- a/impl/java/client/src/main/kotlin/br/com/guiabolso/events/client/http/OkHttpClientAdapter.kt
+++ b/impl/java/client/src/main/kotlin/br/com/guiabolso/events/client/http/OkHttpClientAdapter.kt
@@ -1,0 +1,69 @@
+package br.com.guiabolso.events.client.http
+
+import br.com.guiabolso.events.client.adapter.HttpClientAdapter
+import br.com.guiabolso.events.client.exception.FailedDependencyException
+import br.com.guiabolso.events.client.exception.TimeoutException
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody.Companion.toRequestBody
+import okio.IOException
+import java.io.InterruptedIOException
+import java.net.SocketTimeoutException
+import java.nio.charset.Charset
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+
+class OkHttpClientAdapter(private val template: OkHttpClient = OkHttpClient.Builder().build()) : HttpClientAdapter {
+    private val clients = ConcurrentHashMap<Long, OkHttpClient>()
+
+    override fun post(
+        url: String,
+        headers: Map<String, String>,
+        payload: String,
+        charset: Charset,
+        timeout: Int
+    ): String {
+
+        val client = getClientFor(timeout)
+        val request = okhttp3.Request.Builder()
+            .url(url)
+            .post(payload.toRequestBody())
+            .apply {
+                headers.forEach { (key, value) ->
+                    this.addHeader(key, value)
+                }
+            }
+            .build()
+
+        return try {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    throw IOException("Unexpected response $response")
+                }
+                response.body!!.string()
+            }
+        } catch (ex: Exception) {
+            handleException(ex, url)
+        }
+    }
+
+    private fun getClientFor(requestTimeout: Int): OkHttpClient =
+        clients.computeIfAbsent(requestTimeout.toLong()) { timeout ->
+            template.newBuilder()
+                .callTimeout(timeout, TimeUnit.MILLISECONDS)
+                .build()
+        }
+
+    private fun handleException(ex: Exception, url: String): Nothing {
+        when (ex) {
+            is SocketTimeoutException,
+            is InterruptedIOException -> throw TimeoutException(
+                "Timeout calling $url",
+                ex
+            )
+
+            else -> throw FailedDependencyException(
+                "Failed dependency calling $url", ex
+            )
+        }
+    }
+}

--- a/impl/java/client/src/test/kotlin/br/com/guiabolso/events/client/client/OkHttpClientAdapterTest.kt
+++ b/impl/java/client/src/test/kotlin/br/com/guiabolso/events/client/client/OkHttpClientAdapterTest.kt
@@ -5,6 +5,7 @@ import br.com.guiabolso.events.client.exception.TimeoutException
 import br.com.guiabolso.events.client.http.OkHttpClientAdapter
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 
 import org.junit.jupiter.api.Test
@@ -18,6 +19,11 @@ class OkHttpClientAdapterTest {
     fun before() {
         server = MockWebServer()
         server.start()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        server.close()
     }
 
     @Test

--- a/impl/java/client/src/test/kotlin/br/com/guiabolso/events/client/client/OkHttpClientAdapterTest.kt
+++ b/impl/java/client/src/test/kotlin/br/com/guiabolso/events/client/client/OkHttpClientAdapterTest.kt
@@ -1,0 +1,70 @@
+package br.com.guiabolso.events.client.client
+
+import br.com.guiabolso.events.client.exception.FailedDependencyException
+import br.com.guiabolso.events.client.exception.TimeoutException
+import br.com.guiabolso.events.client.http.OkHttpClientAdapter
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.BeforeEach
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class OkHttpClientAdapterTest {
+    private lateinit var server: MockWebServer
+    private val client = OkHttpClientAdapter()
+
+    @BeforeEach
+    fun before() {
+        server = MockWebServer()
+        server.start()
+    }
+
+    @Test
+    fun `post and request timed out`() {
+        val client = OkHttpClientAdapter()
+
+        assertThrows<TimeoutException> {
+            client.post(
+                url = "http://localhost:${server.port}/events",
+                headers = emptyMap(),
+                payload = "",
+                charset = Charsets.UTF_8,
+                timeout = 1000
+            )
+        }
+    }
+
+    @Test
+    fun `post and fail to connect`() {
+        server.close()
+        assertThrows<FailedDependencyException> {
+            client.post(
+                url = "http://localhost:${server.port}/events",
+                headers = emptyMap(),
+                payload = "",
+                charset = Charsets.UTF_8,
+                timeout = 1000
+            )
+        }
+    }
+
+    @Test
+    fun `post and get a successfully response back`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setBody("Deu bom!")
+        )
+
+        val response = client.post(
+            url = "http://localhost:${server.port}/events",
+            headers = emptyMap(),
+            payload = "empty",
+            charset = Charsets.UTF_8,
+            timeout = 5000
+        )
+
+        assert(response == "Deu bom!")
+    }
+}


### PR DESCRIPTION
O Fuel quando comparado com OkHttp, tem um desempenho muito inferior, okhttp oferece suporte eficiente para operações de IO (okio), suporte para cache de conexão tcp que o feul não oferece, talvez esses sejam os motivos do desempenho baixo avaliando em bechmark interno.